### PR TITLE
(SIMP-113) Skip SimpOS tests for YumRepositories

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
   - 1.9.3
   - 2.0.0
 
+env:
+  - SIMP_SKIP_NON_SIMPOS_TESTS=1
+
 script:
   - 'bundle exec rake spec'
 

--- a/spec/lib/simp/cli/config/item/yum_repositories_spec.rb
+++ b/spec/lib/simp/cli/config/item/yum_repositories_spec.rb
@@ -44,11 +44,16 @@ describe Simp::Cli::Config::Item::YumRepositories do
       expect( File.directory?( File.join( @yum_dist_dir, 'Updates') ) ).to eq( true )
     end
 
-    it 'generates the yum Updates repo metadata' do
-      file =  File.join( @yum_dist_dir, 'Updates', 'repodata', 'repomd.xml' )
-      expect( File.exists?( file )).to eq( true )
-      expect( File.size?( file ) ).to  be_truthy
-    end
+      it 'generates the yum Updates repo metadata' do
+        file =  File.join( @yum_dist_dir, 'Updates', 'repodata', 'repomd.xml' )
+
+        if (value = ENV['SIMP_SKIP_NON_SIMPOS_TESTS'])
+          skip "skipping because env var SIMP_SKIP_NON_SIMPOS_TESTS is set to #{value}"
+        else
+          expect( File.exists?( file )).to eq( true )
+          expect( File.size?( file ) ).to  be_truthy
+        end
+      end
 
     it 'enables simp::yum::enable_simp_repos in hiera' do
       lines = File.readlines( @tmp_yaml_file ).join( "\n" )


### PR DESCRIPTION
This commit enables non-SimpOS testing environments such as TravisCI to
skip YumRepositories tests that rely on SimpOS-specific OS components.

SIMP-112 #comment Introduced env var SIMP_SKIP_NON_SIMPOS_TESTS
SIMP-112 #close