### PR TITLE
(SIMP-287) Fix UTF-8/ASCII-8BIT encoding error

### DIFF
--- a/build/rubygem-simp-cli.el6.spec
+++ b/build/rubygem-simp-cli.el6.spec
@@ -16,7 +16,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.1
+Version: 1.0.2
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -88,6 +88,9 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Thu Jul 23 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.2-0
+- Fixed UTF-8/ASCII-8BIT encoding error in ruby 1.9+
+
 * Wed Jun 24 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.1-0
 - Version bump to account for whatever made the version bump on the Gem
 

--- a/build/rubygem-simp-cli.el7.spec
+++ b/build/rubygem-simp-cli.el7.spec
@@ -12,7 +12,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.1
+Version: 1.0.2
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -80,6 +80,9 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Thu Jul 23 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.2-0
+- Fixed UTF-8/ASCII-8BIT encoding error in ruby 1.9+
+
 * Wed Jun 24 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.1-0
 - Version bump to account for whatever made the version bump on the Gem
 

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.1'
+  VERSION = '1.0.2'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/lib/simp/cli/config/utils.rb
+++ b/lib/simp/cli/config/utils.rb
@@ -87,15 +87,16 @@ class Simp::Cli::Config::Utils
     def encrypt_openldap_hash( string, salt=nil )
        require 'digest/sha1'
        require 'base64'
-       # Ruby 1.8.7 hack to do Random.new.bytes(4):
-       salt = salt || (x = ''; 4.times{ x += ((rand * 255).floor.chr ) }; x)
 
+       # Ruby 1.8.7 hack to do Random.new.bytes(4):
+       salt   = salt || (x = ''; 4.times{ x += ((rand * 255).floor.chr ) }; x)
        digest = Digest::SHA1.digest( string + salt )
 
-       # NOTE: Digest::SHA1.digest in Ruby 2.0.0+ returns a String encoding in
+       # NOTE: Digest::SHA1.digest in Ruby 1.9+ returns a String encoding in
        #       ASCII-8BIT, whereas all other Strings in play are UTF-8
-       if RUBY_VERSION.split('.').first.to_i >= 2
+       if RUBY_VERSION.split('.')[0..1].join('.').to_f > 1.8
          digest = digest.force_encoding( 'UTF-8' )
+         salt   = salt.force_encoding( 'UTF-8' )
        end
 
        "{SSHA}"+Base64.encode64( digest + salt ).chomp


### PR DESCRIPTION
Before this patch, "simp config" would fail in EL7/Ruby 1.9+, due to a
difference in the encoding of salt (ASCII-8BIT, due to a workaround for
Ruby 1.8.7) and other Strings when concatenated inside Base64.encode64.

This patch forces the encoding for salt to UTF-8 if the version of Ruby
is newer than 1.8, and bumps the gem and RPM release to 1.0.2.

SIMP-287 #close #comment Force encoding of salt to UTF-8 in ruby 2.0.0