### PR TITLE
(SIMP-292) Fix usability issues in 'simp config'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,10 +23,10 @@ gemspec
 
 # mandatory gems
 gem 'bundler'
-#  gem 'rake'
-#  gem 'highline', '~> 1.6.1'  # NOTE: 1.7+ requires ruby 1.9.3+
-#  gem 'puppet'
-#  gem 'facter'
+gem 'rake'
+gem 'highline', '~> 1.6.1'  # NOTE: 1.7+ requires ruby 1.9.3+
+gem 'puppet'
+gem 'facter'
 
 
 
@@ -51,6 +51,6 @@ group :development do
   gem 'guard-shell'
   gem 'guard-rspec'
 
-  # Generate HISTORY.md from git tags
+  # Generate HISTORY.md from git tags (experimental, but promising)
   gem 'gitlog-md'
 end

--- a/lib/simp/cli/config/item.rb
+++ b/lib/simp/cli/config/item.rb
@@ -2,6 +2,7 @@ require 'highline/import'
 require 'puppet'
 require 'yaml'
 require File.expand_path( 'utils', File.dirname(__FILE__) )
+require 'highline'
 
 module Simp; end
 class Simp::Cli; end
@@ -126,7 +127,12 @@ module Simp::Cli::Config
 
     # ask an interactive question (via stdout/stdin)
     def query_ask
-      value = ask( "<%= color('#{@key}', WHITE, BOLD) %>:", highline_question_type ) do |q|
+      # NOTE: This trailing space at the end of the String obliquely instructs
+      # Highline to keep the prompt on the same line as the question.  If the
+      # String did not end with a space or tab, Highline would move the input
+      # prompt to the next line (which, for our purposes, looks confusing)
+      value = ask( "<%= color('#{@key}', WHITE, BOLD) %>: ",
+                  highline_question_type ) do |q|
         q.default = default_value unless default_value.to_s.empty?
 
         # validate input via the validate() method
@@ -134,7 +140,7 @@ module Simp::Cli::Config
 
         # if the answer is not valid, construct a reply:
         q.responses[:not_valid] =  "<%= color( %q{Invalid answer!}, RED ) %>\n"
-        q.responses[:not_valid] += "<%= color( %q{#{ (not_valid_message || description) }}, CYAN) %>\n"
+        q.responses[:not_valid] += "<%= color( %q{#{ (not_valid_message || description) }}, YELLOW) %>\n"
         q.responses[:not_valid] += "#{q.question}  |#{q.default}|"
 
         query_extras q
@@ -271,17 +277,19 @@ module Simp::Cli::Config
     def query_generate_password
       password = false
       default  = @generate_by_default ? 'yes' : 'no'
-      if agree( "generate a password?" ){ |q| q.default = default }
+      if agree( "auto-generate a password? " ){ |q| q.default = default }
         password = Simp::Cli::Config::Utils.generate_password
         say "<%= color( %q{#{''.ljust(80,'-')}}, GREEN)%>\n"
-        say "<%= color( %q{NOTE: }, GREEN, BOLD)%>" +
+        say '<%= color( %q{NOTE: }, GREEN, BOLD)%>' +
             "<%= color( %q{ the generated password is: }) %>\n"
         say "\n"
         say "<%= color( %q{   #{password}}, YELLOW, BOLD )%>  "
         say "\n"
         say "\n"
-        say "Please remember it!"
+        say 'Please remember it!'
         say "<%= color( %q{#{''.ljust(80,'-')}}, GREEN)%>\n"
+        say_blue '*** Press enter to continue ***' , ['BOLD', 'BLINK']
+        ask ''
       end
       password
     end
@@ -335,7 +343,9 @@ module Simp::Cli::Config
     end
 
     def not_valid_message
-      "enter a comma or space-delimited list"
+      extra = 'hit enter to skip'
+      extra = "hit enter to accept default value" if default_value
+      "enter a comma or space-delimited list (#{extra})"
     end
 
     def query_extras( q )
@@ -343,7 +353,10 @@ module Simp::Cli::Config
       # It would probably be better (but more complex) to provide native Array
       # support for highline.
       # TODO: Override #query_ask using Highline's #gather?
-      q.default = q.default.join( " " ) if q.default.is_a? Array
+      q.default  = q.default.join( " " ) if q.default.is_a? Array
+      reminder = ::HighLine.color( not_valid_message,
+                            ::HighLine.const_get('YELLOW') )
+      q.question = "#{reminder}\n#{q.question}"
       q
     end
 

--- a/lib/simp/cli/config/item/log_servers.rb
+++ b/lib/simp/cli/config/item/log_servers.rb
@@ -18,14 +18,6 @@ module Simp::Cli::Config
       nil
     end
 
-    def recommended_value
-      if @config_items.key? 'hostname'
-        [ @config_items.fetch('hostname').value ]
-      else
-        nil
-      end
-    end
-
     def validate_item item
       ( Simp::Cli::Config::Utils.validate_hostname( item ) ||
         Simp::Cli::Config::Utils.validate_fqdn( item ) ||

--- a/lib/simp/cli/config/item/rsync_server.rb
+++ b/lib/simp/cli/config/item/rsync_server.rb
@@ -12,7 +12,8 @@ module Simp::Cli::Config
       @key         = 'rsync::server'
       @description = 'rsync server (usually the primary puppet master)'
       @__warning   = false
-      @file = '/etc/rsyncd.conf'
+      @file        = '/etc/rsyncd.conf'
+      @skip_query  = true
     end
 
     def os_value

--- a/lib/simp/cli/config/item/yum_repositories.rb
+++ b/lib/simp/cli/config/item/yum_repositories.rb
@@ -13,7 +13,7 @@ module Simp::Cli::Config
       super
       @key         = 'yum::repositories'
       @description = %Q{Sets up the yum repositores for SIMP on apply. (apply-only; noop)}
-      @www_yum_dir = File.exists?( '/srv/www/yum/') ? '/srv/www/yum' : '/var/www/yum'
+      @www_yum_dir = File.exists?( '/var/www/yum/') ? '/var/www/yum' : '/srv/www/yum'
       @yum_repos_d = '/etc/yum.repos.d'
       @yaml_file   = '/etc/puppet/environments/production/hieradata/hosts/puppet.your.domain.yaml'
     end

--- a/spec/lib/simp/cli/config/item/log_servers_spec.rb
+++ b/spec/lib/simp/cli/config/item/log_servers_spec.rb
@@ -12,11 +12,6 @@ describe Simp::Cli::Config::Item::LogServers do
       expect( @ci.recommended_value ).to be_nil
     end
   end
-  describe "#recommended_value" do
-    it "recommends nil when gateway is unavailable" do
-      expect( @ci.recommended_value ).to be_nil
-    end
-  end
 
   describe "#validate" do
     it "validates array with good hosts" do
@@ -41,6 +36,11 @@ describe Simp::Cli::Config::Item::LogServers do
       expect( @ci.validate ['log.loggitylog.org.'] ).to eq false
       expect( @ci.validate ['.log.loggitylog.org'] ).to eq false
 
+    end
+
+    it "accepts an empty list" do
+      expect( @ci.validate [] ).to eq true
+      expect( @ci.validate "" ).to eq true
     end
   end
 

--- a/spec/lib/simp/cli/config/item/ntp_servers_spec.rb
+++ b/spec/lib/simp/cli/config/item/ntp_servers_spec.rb
@@ -5,6 +5,7 @@ require_relative( 'spec_helper' )
 describe Simp::Cli::Config::Item::NTPServers do
   before :each do
     @ci = Simp::Cli::Config::Item::NTPServers.new
+    @ci.silent = true
   end
 
 #  describe "#recommended_value" do
@@ -30,6 +31,11 @@ describe Simp::Cli::Config::Item::NTPServers do
       expect( @ci.validate ['pool.ntp.org.'] ).to eq false
       expect( @ci.validate ['192.168.1.1.'] ).to eq false
       expect( @ci.validate ['1.2.3.4/24'] ).to eq false
+    end
+
+    it "accepts an empty list" do
+      expect( @ci.validate [] ).to eq true
+      expect( @ci.validate "" ).to eq true
     end
   end
 


### PR DESCRIPTION
SIMP-295 #close #comment Fixed speling.
SIMP-296 #comment ntpd::servers are now optional in 'simp config'
SIMP-296 #comment log_servers are now optional in 'simp config'
SIMP-296 #close
SIMP-297 #close #comment Generated passwords pause until 'enter'.