### PR TITLE
(SIMP-17) Fix ldap when use_ldap is false

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,2 @@
+--format documentation
 --color
---require spec_helper

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -190,7 +190,7 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli
       track_output("#{pupcmd}")
       i = i + 1
     end
-    if i == 3
+    if i == 3 and $use_ldap
       puts "   \033[1mWarning\033[0m: It does not look like LDAP was properly configured to start."
       puts "   Please check your configuration."
     else

--- a/lib/simp/cli/config/item/add_ldap_to_hiera.rb
+++ b/lib/simp/cli/config/item/add_ldap_to_hiera.rb
@@ -1,0 +1,43 @@
+require "resolv"
+require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../utils', File.dirname(__FILE__) )
+
+module Simp; end
+class Simp::Cli; end
+module Simp::Cli::Config
+  class Item::AddLdapToHiera < ActionItem
+    attr_accessor :dir
+
+    def initialize
+      super
+      @key         = 'puppet::add_ldap_to_hiera'
+      @description = %Q{Adds simp::ldap_server to hieradata/hosts/puppet.your.domain.yaml (apply-only; noop).}
+      @dir         = "/etc/puppet/environments/production/hieradata/hosts"
+      @file        = nil
+    end
+
+    def apply
+      success = true
+      fqdn    = @config_items.fetch( 'hostname' ).value
+      file    = File.join( @dir, "#{fqdn}.yaml")
+
+      say_green 'Adding simp::ldap_server to the <domain>.yaml file' if !@silent
+
+      if File.exists?(file)
+        success = true
+        yaml = File.open(file, "a") do |f|
+          f.puts "  - 'simp::ldap_server'"
+        end
+      else
+        success = false
+        say_yellow "WARNING: file not found: #{file}"
+      end
+      success
+    end
+
+
+    def contains_ldap?( line )
+      (line =~ /^\s*-\s+(([a-z_:'"]*::)*(open)*ldap|(open)*ldap[a-z_:'"]*)/m) ? true : false
+    end
+  end
+end

--- a/lib/simp/cli/config/item/remove_ldap_from_hiera.rb
+++ b/lib/simp/cli/config/item/remove_ldap_from_hiera.rb
@@ -1,0 +1,47 @@
+require "resolv"
+require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../utils', File.dirname(__FILE__) )
+
+module Simp; end
+class Simp::Cli; end
+module Simp::Cli::Config
+  class Item::RemoveLdapFromHiera < ActionItem
+    attr_accessor :dir
+
+    def initialize
+      super
+      @key         = 'puppet::remove_ldap_from_hiera'
+      @description = %Q{Removes any ldap classes from hieradata/hosts/puppet.your.domain.yaml (apply-only; noop).}
+      @dir         = "/etc/puppet/environments/production/hieradata/hosts"
+      @file        = nil
+    end
+
+    def apply
+      success = true
+      fqdn    = @config_items.fetch( 'hostname' ).value
+      file    = File.join( @dir, "#{fqdn}.yaml")
+
+      say_green 'Removing ldap classes from the <domain>.yaml file' if !@silent
+
+      if File.exists?(file)
+        lines = File.open(file,'r').readlines
+
+        File.open(file, 'w') do |f|
+          lines.each do |line|
+            line.chomp!
+            f.puts line if !strip_line?(line)
+          end
+        end
+      else
+        success = false
+        say_yellow "WARNING: file not found: #{file}"
+      end
+      success
+    end
+
+
+    def strip_line?( line )
+      (line =~ /^\s*-\s+(([a-z_:'"]*::)*(open)*ldap|(open)*ldap[a-z_:'"]*)/m) ? true : false
+    end
+  end
+end

--- a/lib/simp/cli/config/item_list_factory.rb
+++ b/lib/simp/cli/config/item_list_factory.rb
@@ -104,6 +104,7 @@ class Simp::Cli::Config::ItemListFactory
       # ==== ldap ====
       - UseLdap:
          true:
+          - AddLdapToHiera
           - LdapBaseDn
           - LdapBindDn
           - LdapBindPw
@@ -115,6 +116,8 @@ class Simp::Cli::Config::ItemListFactory
           - LdapRootHash
           - LdapMaster
           - LdapUri
+         false:
+          - RemoveLdapFromHiera
 
       # ==== rsync ====
       - RsyncBase

--- a/spec/lib/simp/cli/config/item/add_ldap_to_hiera_spec.rb
+++ b/spec/lib/simp/cli/config/item/add_ldap_to_hiera_spec.rb
@@ -1,0 +1,58 @@
+require 'simp/cli/config/item/add_ldap_to_hiera'
+require 'simp/cli/config/item/hostname'
+require_relative( 'spec_helper' )
+
+describe Simp::Cli::Config::Item::AddLdapToHiera do
+  before :each do
+    @ci        = Simp::Cli::Config::Item::AddLdapToHiera.new
+    @ci.silent = true
+  end
+
+  # describe "#contains_ldap?" do
+  #   it 'decides to strip ::ldap and openldap:: classes' do
+  #     expect(@ci.contains_ldap?('  - simp::ldap_server')).to be true
+  #     expect(@ci.contains_ldap?(%q{  - 'simp::ldap_server'})).to be true
+  #     expect(@ci.contains_ldap?('  - openldap')).to be true
+  #     expect(@ci.contains_ldap?('  - openldap::server')).to be true
+  #   end
+  #
+  #   it 'rejects false positives' do
+  #     expect(@ci.contains_ldap?( '#  - simp::ldap_server')).to be false
+  #     expect(@ci.contains_ldap?('  - randomldap::foo')).to be false
+  #   end
+  # end
+
+  describe "#apply" do
+    context "with a valid fqdn" do
+      before :each do
+        @fqdn            = 'hostname.domain.tld'
+        @files_dir       = File.expand_path( 'files', File.dirname( __FILE__ ) )
+        @tmp_dir         = File.expand_path( 'tmp', File.dirname( __FILE__ ) )
+        @file            = File.join( @files_dir,'puppet.your.domain.yaml')
+        @tmp_file        = File.join( @tmp_dir, "#{@fqdn}.yaml" )
+        @ci.dir          = @tmp_dir
+
+        item             = Simp::Cli::Config::Item::Hostname.new
+        item.value       = @fqdn
+        @ci.config_items[item.key] = item
+        @new_file        = File.join( @tmp_dir, "#{@fqdn}.yaml" )
+
+        [@tmp_file, @new_file].each do |file|
+          FileUtils.rm file if File.exists? file
+        end
+
+        FileUtils.mkdir_p   @tmp_dir
+        FileUtils.copy_file @file, @tmp_file
+
+        @result = @ci.apply
+      end
+
+      it "file will contain the simp::ldap_server class" do
+        expect( File.open(@tmp_file).readlines.join("\n") ).to match(/simp::ldap_server/)
+      end
+    end
+  end
+
+  it_behaves_like "an Item that doesn't output YAML"
+  it_behaves_like 'a child of Simp::Cli::Config::Item'
+end

--- a/spec/lib/simp/cli/config/item/files/puppet.your.domain.yaml
+++ b/spec/lib/simp/cli/config/item/files/puppet.your.domain.yaml
@@ -17,6 +17,5 @@ simp::yum::enable_simp_repos : false
 
 classes :
   - 'simp::server'
-  - 'simp::ldap_server'
   - 'simp::yum_server'
   - 'simp::kickstart_server'

--- a/spec/lib/simp/cli/config/item/remove_ldap_from_hiera_spec.rb
+++ b/spec/lib/simp/cli/config/item/remove_ldap_from_hiera_spec.rb
@@ -1,0 +1,58 @@
+require 'simp/cli/config/item/remove_ldap_from_hiera'
+require 'simp/cli/config/item/hostname'
+require_relative( 'spec_helper' )
+
+describe Simp::Cli::Config::Item::RemoveLdapFromHiera do
+  before :each do
+    @ci        = Simp::Cli::Config::Item::RemoveLdapFromHiera.new
+    @ci.silent = true
+  end
+
+  describe "#strip_line?" do
+    it 'decides to strip ::ldap and openldap:: classes' do
+      expect(@ci.strip_line?('  - simp::ldap_server')).to be true
+      expect(@ci.strip_line?(%q{  - 'simp::ldap_server'})).to be true
+      expect(@ci.strip_line?('  - openldap')).to be true
+      expect(@ci.strip_line?('  - openldap::server')).to be true
+    end
+
+    it 'rejects false positives' do
+      expect(@ci.strip_line?( '#  - simp::ldap_server')).to be false
+      expect(@ci.strip_line?('  - randomldap::foo')).to be false
+    end
+  end
+
+  describe "#apply" do
+    context "with a valid fqdn" do
+      before :each do
+        @fqdn            = 'hostname.domain.tld'
+        @files_dir       = File.expand_path( 'files', File.dirname( __FILE__ ) )
+        @tmp_dir         = File.expand_path( 'tmp', File.dirname( __FILE__ ) )
+        @file            = File.join( @files_dir,'puppet.your.domain.yaml')
+        @tmp_file        = File.join( @tmp_dir, "#{@fqdn}.yaml" )
+        @ci.dir          = @tmp_dir
+
+        item             = Simp::Cli::Config::Item::Hostname.new
+        item.value       = @fqdn
+        @ci.config_items[item.key] = item
+        @new_file        = File.join( @tmp_dir, "#{@fqdn}.yaml" )
+
+        [@tmp_file, @new_file].each do |file|
+          FileUtils.rm file if File.exists? file
+        end
+
+        FileUtils.mkdir_p   @tmp_dir
+        FileUtils.copy_file @file, @tmp_file
+
+        @result = @ci.apply
+      end
+
+      it "file won't have any lines containing ldap" do
+        expect( File.open(@tmp_file).readlines.join("\n") ).not_to match(/ldap/)
+      end
+    end
+  end
+
+  it_behaves_like "an Item that doesn't output YAML"
+  it_behaves_like 'a child of Simp::Cli::Config::Item'
+end

--- a/spec/lib/simp/cli/config/item/spec_helper.rb
+++ b/spec/lib/simp/cli/config/item/spec_helper.rb
@@ -4,6 +4,12 @@ shared_examples 'a child of Simp::Cli::Config::Item' do
       expect( @ci.to_yaml_s ).not_to match(/FIXME/)
     end
   end
+
+  describe '#key' do
+    it 'returns a String' do
+      expect( @ci.key ).to be_a_kind_of(String)
+    end
+  end
 end
 
 


### PR DESCRIPTION
Added an remove_ldap.rb to simp-cli to remove instances of ldap in
hieradata/hosts/#{fqdn}.yaml. Configured the item to run after the
item use_ldap returns false.

SIMP-17 #close