### PR TITLE
(SIMP-359) Updates repo not being populated with packages.

### DIFF
--- a/lib/simp/cli/config/item/yum_repositories.rb
+++ b/lib/simp/cli/config/item/yum_repositories.rb
@@ -32,7 +32,7 @@ module Simp::Cli::Config
         Dir.chdir(yumpath) do
           FileUtils.mkdir('Updates') unless File.directory?('Updates')
           Dir.chdir('Updates') do
-            system( %q(find . -type f -name '*.rpm' -exec ln -sf {} \\;) )
+            system( %q(find .. -type f -name '*.rpm' -exec ln -sf {} \\;) )
             cmd = 'createrepo -qqq -p --update .'
             if @silent
               cmd << ' &> /dev/null'


### PR DESCRIPTION
Typo prevented packages from being symlinked to Updates.

SIMP-359 #close Updates has no packages!