### PR TITLE
(SIMP-353) Add use_fips item to 'simp config'

### DIFF
--- a/build/rubygem-simp-cli.el6.spec
+++ b/build/rubygem-simp-cli.el6.spec
@@ -16,7 +16,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.3
+Version: 1.0.4
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -88,6 +88,9 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Wed Aug 26 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.4-0
+- Added use_fips item for 'simp config'
+
 * Wed Aug 12 2015 Nick Miller <nick.miller@onyxpoint.com> - 1.0.3-0
 - use_ldap can now be set to false.
 - Added a function to add ldap to hiera when needed.

--- a/build/rubygem-simp-cli.el7.spec
+++ b/build/rubygem-simp-cli.el7.spec
@@ -12,7 +12,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.3
+Version: 1.0.4
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -80,6 +80,9 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Wed Aug 26 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.4-0
+- Added use_fips item for 'simp config'
+
 * Wed Aug 12 2015 Nick Miller <nick.miller@onyxpoint.com> - 1.0.3-0
 - use_ldap can now be set to false.
 - Added a function to add ldap to hiera when needed.

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/lib/simp/cli/config/item/use_fips.rb
+++ b/lib/simp/cli/config/item/use_fips.rb
@@ -1,0 +1,23 @@
+require 'highline/import'
+require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../utils', File.dirname(__FILE__) )
+
+module Simp; end
+class Simp::Cli; end
+module Simp::Cli::Config
+  class Item::UseFips < YesNoItem
+    def initialize
+      super
+      @key         = 'use_fips'
+      @description = %q{enable fips on this system.}
+    end
+
+    def os_value
+      Facter.value('fips_enabled') ? 'yes' : 'no'
+    end
+
+    def recommended_value
+      os_value || 'yes'
+    end
+  end
+end

--- a/lib/simp/cli/config/item_list_factory.rb
+++ b/lib/simp/cli/config/item_list_factory.rb
@@ -82,6 +82,7 @@ class Simp::Cli::Config::ItemListFactory
       - UseIPtables
       - CommonRunLevelDefault
       - UseSELinux
+      - UseFips
       - SetGrubPassword:
          true:
           - GrubPassword

--- a/spec/lib/simp/cli/config/item/use_fips_spec.rb
+++ b/spec/lib/simp/cli/config/item/use_fips_spec.rb
@@ -1,0 +1,29 @@
+require 'simp/cli/config/item/use_fips'
+require 'rspec/its'
+require_relative( 'spec_helper' )
+
+describe Simp::Cli::Config::Item::UseFips do
+  before :each do
+    @ci = Simp::Cli::Config::Item::UseFips.new
+  end
+
+  describe "#validate" do
+    it "validates yes/no" do
+      expect( @ci.validate 'yes' ).to eq true
+      expect( @ci.validate 'y' ).to   eq true
+      expect( @ci.validate 'Y' ).to   eq true
+      expect( @ci.validate 'no' ).to  eq true
+      expect( @ci.validate 'n' ).to   eq true
+      expect( @ci.validate 'NO' ).to  eq true
+      expect( @ci.validate true ).to  eq true
+      expect( @ci.validate false ).to eq true
+    end
+
+    it "doesn't validate other things" do
+      expect( @ci.validate 'ydd' ).to  eq false
+      expect( @ci.validate 'gsdg' ).to eq false
+    end
+  end
+
+  it_behaves_like "a child of Simp::Cli::Config::Item"
+end


### PR DESCRIPTION
Before this update, 'simp config' did not include an item to enable FIPS.  Now it does.