### PR TITLE
(SIMP-445) Add failover_log_servers to simp config

### DIFF
--- a/lib/simp/cli/config/item/failover_log_servers.rb
+++ b/lib/simp/cli/config/item/failover_log_servers.rb
@@ -1,0 +1,27 @@
+require "resolv"
+require 'highline/import'
+require File.expand_path( '../item',  File.dirname(__FILE__) )
+require File.expand_path( '../utils', File.dirname(__FILE__) )
+
+module Simp; end
+class Simp::Cli; end
+module Simp::Cli::Config
+  class Item::FailoverLogServers < ListItem
+    def initialize
+      super
+      @key         = 'failover_log_servers'
+      @description = 'Failover log server(s) in case your log servers(s) fail.'
+      @allow_empty_list = true
+    end
+
+    def os_value
+      nil
+    end
+
+    def validate_item item
+      ( Simp::Cli::Config::Utils.validate_hostname( item ) ||
+        Simp::Cli::Config::Utils.validate_fqdn( item ) ||
+        Simp::Cli::Config::Utils.validate_ip( item ) )
+    end
+  end
+end

--- a/lib/simp/cli/config/item_list_factory.rb
+++ b/lib/simp/cli/config/item_list_factory.rb
@@ -77,6 +77,7 @@ class Simp::Cli::Config::ItemListFactory
       # ==== globals ====
       - NTPServers          NOAPPLY
       - LogServers
+      - FailoverLogServers
       - SimpYumServers
       - UseAuditd
       - UseIPtables

--- a/spec/lib/simp/cli/config/item/failover_log_servers_spec.rb
+++ b/spec/lib/simp/cli/config/item/failover_log_servers_spec.rb
@@ -1,0 +1,49 @@
+require 'simp/cli/config/item/failover_log_servers'
+require 'rspec/its'
+require_relative( 'spec_helper' )
+
+describe Simp::Cli::Config::Item::FailoverLogServers do
+  before :each do
+    @ci = Simp::Cli::Config::Item::FailoverLogServers.new
+  end
+
+  describe "#recommended_value" do
+    it "recommends nil when gateway is unavailable" do
+      expect( @ci.recommended_value ).to be_nil
+    end
+  end
+
+  describe "#validate" do
+    it "validates array with good hosts" do
+      expect( @ci.validate ['log'] ).to eq true
+      expect( @ci.validate ['log-server'] ).to eq true
+      expect( @ci.validate ['log.loggitylog.org'] ).to eq true
+      expect( @ci.validate ['192.168.1.1'] ).to eq true
+      expect( @ci.validate ['192.168.1.1', 'log.loggitylog.org'] ).to eq true
+
+      # failover_log_servers is optional and can be empty
+      expect( @ci.validate nil   ).to eq true
+      expect( @ci.validate '' ).to    eq true
+      expect( @ci.validate '   ' ).to eq true
+    end
+
+    it "doesn't validate array with bad hosts" do
+      expect( @ci.validate 0     ).to eq false
+      expect( @ci.validate false ).to eq false
+      expect( @ci.validate [nil] ).to eq false
+      expect( @ci.validate ['log-'] ).to eq false
+      expect( @ci.validate ['-log'] ).to eq false
+      expect( @ci.validate ['log.loggitylog.org.'] ).to eq false
+      expect( @ci.validate ['.log.loggitylog.org'] ).to eq false
+
+    end
+
+    it "accepts an empty list" do
+      expect( @ci.validate [] ).to eq true
+      expect( @ci.validate "" ).to eq true
+    end
+  end
+
+  it_behaves_like "a child of Simp::Cli::Config::Item"
+end
+


### PR DESCRIPTION
This commit updates `simp config` to ask for a list of syslog servers to
be used as failover targets.  The answer will populate the top-level
Hiera key, `failover_log_servers`.

SIMP-445 #close #comment Added failover_log_servers to `simp config`
SIMP-192 #comment Added failover_log_servers to `simp config`