### PR TITLE
(SIMP-495) Remove vestigial yaml/store require

### DIFF
--- a/lib/simp/cli/config/questionnaire.rb
+++ b/lib/simp/cli/config/questionnaire.rb
@@ -4,7 +4,6 @@ module Simp::Cli::Config; end
 
 require File.expand_path( '../commands/config', File.dirname(__FILE__) )
 require File.expand_path( 'utils', File.dirname(__FILE__) )
-require 'yaml/store' # for safety-saving
 
 # Builds a SIMP configuration profile based on an Array of Config::Items
 #


### PR DESCRIPTION
Before this commit, `simp config` would fail when run on a system that
booted into FIPS mode, due to an MD5 call within yaml/store.  yaml/store
is no longer required by `simp config`, so it has been removed.

SIMP-495 #close #comment Removed `require 'yaml/store'` for FIPS mode