### PR TITLE
(SIMP-499) Set digest algo before 'simp config'

### DIFF
--- a/build/rubygem-simp-cli.el6.spec
+++ b/build/rubygem-simp-cli.el6.spec
@@ -16,7 +16,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.6
+Version: 1.0.7
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -88,6 +88,10 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Mon Sep 28 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0-7-0
+- Ensure that the puppet digest algorithm is set to sha256 prior to running
+  'simp config'
+
 * Fri Sep 18 2015 Kendall Moore <kmoore@keywcorp.com> - 1.0.6-0
 - Set the keylength variable in puppet.conf
 

--- a/build/rubygem-simp-cli.el7.spec
+++ b/build/rubygem-simp-cli.el7.spec
@@ -12,7 +12,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.6
+Version: 1.0.7
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -80,6 +80,10 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Mon Sep 28 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0-7-0
+- Ensure that the puppet digest algorithm is set to sha256 prior to running
+  'simp config'
+
 * Fri Sep 18 2015 Kendall Moore <kmoore@keywcorp.com> - 1.0.6-0
 - Set the keylength variable in puppet.conf
 

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.6'
+  VERSION = '1.0.7'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/lib/simp/cli/commands/config.rb
+++ b/lib/simp/cli/commands/config.rb
@@ -80,11 +80,11 @@ class Simp::Cli::Commands::Config  < Simp::Cli
       @options[:noninteractive] += 1
     end
 
-    opts.on("-s", "--skip-safety-save",         "Ignore any saftey-save files") do
+    opts.on("-s", "--skip-safety-save",         "Ignore any safety-save files") do
       @options[:use_safety_save] = false
     end
 
-    opts.on("-S", "--accept-safety-save",  "Automatically apply any saftey-save files") do
+    opts.on("-S", "--accept-safety-save",  "Automatically apply any safety-save files") do
       @options[:autoaccept_safety_save] = true
     end
 
@@ -166,7 +166,7 @@ class Simp::Cli::Commands::Config  < Simp::Cli
       answers_hash = YAML.load(File.read(file))
       answers_hash.empty?
     rescue Errno::EACCES
-      error = "WARNING: Could not access the anwers file '#{file}'!"
+      error = "WARNING: Could not access the answers file '#{file}'!"
       say "<%= color(%q{#{error}}, YELLOW) %>\n"
     rescue
       # If the file existed, but ingest failed, then there's a problem
@@ -176,9 +176,15 @@ class Simp::Cli::Commands::Config  < Simp::Cli
     answers_hash
   end
 
-
-
   def self.run(args = [])
+    # This is a one-off prep item needed for FIPS processing
+    %x(puppet config set digest_algorithm sha256)
+    unless $?.success?
+      error = 'ERROR: Could not set "digest_algorithm" to "sha256"'
+      say "\n<%= color(%q{#{error}}, RED) %>\n"
+      exit 1
+    end
+
     begin
       super # parse @options
     rescue OptionParser::InvalidOption=> e
@@ -197,7 +203,7 @@ class Simp::Cli::Commands::Config  < Simp::Cli
     # NOTE: answers from an interrupted session take precedence over input file
     answers_hash = saved_session.merge( answers_hash )
 
-    # NOTE: answers provided from the cli take precendence over everything else
+    # NOTE: answers provided from the cli take precedence over everything else
     cli_answers  = Hash[ ARGV[1..-1].map{ |x| x.split '=' } ]
     answers_hash = answers_hash.merge( cli_answers )
 


### PR DESCRIPTION
In FIPS mode, the system must have the digest algorithm set to sha256
prior to running 'simp config'.

SIMP-499 #close