### PR TITLE
(SIMP-499) Set digest algo for 'simp config'+FIPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.*.sw?
+/dist
+/pkg
+/.rspec_system
+/.bundle
+/vendor
+/Gemfile.lock

--- a/build/rubygem-simp-cli.el6.spec
+++ b/build/rubygem-simp-cli.el6.spec
@@ -16,7 +16,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.6
+Version: 1.0.7
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -88,6 +88,10 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Mon Sep 28 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0-7-0
+- Ensure that the puppet digest algorithm is set to sha256 prior if FIPS
+  mode is enabled in 'simp config'
+
 * Fri Sep 18 2015 Kendall Moore <kmoore@keywcorp.com> - 1.0.6-0
 - Set the keylength variable in puppet.conf
 

--- a/build/rubygem-simp-cli.el7.spec
+++ b/build/rubygem-simp-cli.el7.spec
@@ -12,7 +12,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.6
+Version: 1.0.7
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -80,6 +80,10 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Mon Sep 28 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0-7-0
+- Ensure that the puppet digest algorithm is set to sha256 prior if FIPS
+  mode is enabled in 'simp config'
+
 * Fri Sep 18 2015 Kendall Moore <kmoore@keywcorp.com> - 1.0.6-0
 - Set the keylength variable in puppet.conf
 

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.6'
+  VERSION = '1.0.7'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/lib/simp/cli/commands/config.rb
+++ b/lib/simp/cli/commands/config.rb
@@ -80,11 +80,11 @@ class Simp::Cli::Commands::Config  < Simp::Cli
       @options[:noninteractive] += 1
     end
 
-    opts.on("-s", "--skip-safety-save",         "Ignore any saftey-save files") do
+    opts.on("-s", "--skip-safety-save",         "Ignore any safety-save files") do
       @options[:use_safety_save] = false
     end
 
-    opts.on("-S", "--accept-safety-save",  "Automatically apply any saftey-save files") do
+    opts.on("-S", "--accept-safety-save",  "Automatically apply any safety-save files") do
       @options[:autoaccept_safety_save] = true
     end
 
@@ -166,7 +166,7 @@ class Simp::Cli::Commands::Config  < Simp::Cli
       answers_hash = YAML.load(File.read(file))
       answers_hash.empty?
     rescue Errno::EACCES
-      error = "WARNING: Could not access the anwers file '#{file}'!"
+      error = "WARNING: Could not access the answers file '#{file}'!"
       say "<%= color(%q{#{error}}, YELLOW) %>\n"
     rescue
       # If the file existed, but ingest failed, then there's a problem
@@ -175,8 +175,6 @@ class Simp::Cli::Commands::Config  < Simp::Cli
 
     answers_hash
   end
-
-
 
   def self.run(args = [])
     begin
@@ -197,7 +195,7 @@ class Simp::Cli::Commands::Config  < Simp::Cli
     # NOTE: answers from an interrupted session take precedence over input file
     answers_hash = saved_session.merge( answers_hash )
 
-    # NOTE: answers provided from the cli take precendence over everything else
+    # NOTE: answers provided from the cli take precedence over everything else
     cli_answers  = Hash[ ARGV[1..-1].map{ |x| x.split '=' } ]
     answers_hash = answers_hash.merge( cli_answers )
 

--- a/lib/simp/cli/config/item.rb
+++ b/lib/simp/cli/config/item.rb
@@ -400,7 +400,7 @@ module Simp::Cli::Config
       if @skip_apply || (not_root_msg.size != 0)
         extra = "<%= color( %q{(skipping apply#{not_root_msg})}, MAGENTA, BOLD)%> "
         say( "#{extra}#{@key}" ) unless @silent
-        if !(@value.nil? || @value.empty?)
+        if !(@value.nil? || @value.class == TrueClass || @value.class == FalseClass || @value.empty?)
           say( "= '<%= color( %q{#{@value}}, BOLD )%>'\n" ) unless @silent
         end
       else

--- a/lib/simp/cli/config/item/puppet_server.rb
+++ b/lib/simp/cli/config/item/puppet_server.rb
@@ -11,7 +11,6 @@ module Simp::Cli::Config
       super
       @key         = 'puppet::server'
       @description = %q{The Hostname or FQDN of the puppet server.}
-#      @fact        = 'fqdn'
     end
 
     def os_value

--- a/lib/simp/cli/config/item/use_fips.rb
+++ b/lib/simp/cli/config/item/use_fips.rb
@@ -6,10 +6,21 @@ module Simp; end
 class Simp::Cli; end
 module Simp::Cli::Config
   class Item::UseFips < YesNoItem
+    include Simp::Cli::Config::SafeApplying
+
     def initialize
       super
       @key         = 'use_fips'
-      @description = %q{enable fips on this system.}
+      @description = %q{Enable FIPS mode on this system.
+
+FIPS mode enforces strict compliance with FIPS-140-2.  All core SIMP modules
+can support this configuration.
+
+IMPORTANT: Be sure you know the security tradeoffs of FIPS-140-2 compliance.
+FIPS mode disables the use of MD5 and may require weaker ciphers or key lengths
+than your security policies allow.
+}
+     @allow_user_apply = true
     end
 
     def os_value
@@ -18,6 +29,17 @@ module Simp::Cli::Config
 
     def recommended_value
       os_value || 'yes'
+    end
+
+    def apply
+      if @value
+        # This is a one-off prep item needed to handle Puppet certs w/FIPS mode
+        %x(puppet config set digest_algorithm sha256)
+        $?.success?
+      else
+        puts 'not using FIPS mode: noop'
+        true # we applied nothing, successfully!
+      end
     end
   end
 end

--- a/lib/simp/cli/config/item_list_factory.rb
+++ b/lib/simp/cli/config/item_list_factory.rb
@@ -44,6 +44,7 @@ class Simp::Cli::Config::ItemListFactory
       # - ItemG
       ---
       # ==== network ====
+      - UseFips
       - NetworkInterface
       - SetupNIC:
          true:
@@ -83,7 +84,6 @@ class Simp::Cli::Config::ItemListFactory
       - UseIPtables
       - CommonRunLevelDefault
       - UseSELinux
-      - UseFips
       - SetGrubPassword:
          true:
           - GrubPassword


### PR DESCRIPTION
In FIPS mode, the system must have the digest algorithm set to sha256
when running 'simp config'.

SIMP-499 #close #comment FIPS mode sets puppet digest_algorithm

Change-Id: If7d27c5e0d0044835b328fae22eb103d9a4d8381