### PR TITLE
(SIMP-497) Ensure path to fips_enabled fact

### DIFF
--- a/lib/simp/cli/commands/config.rb
+++ b/lib/simp/cli/commands/config.rb
@@ -186,6 +186,10 @@ class Simp::Cli::Commands::Config  < Simp::Cli
       exit 1
     end
 
+    # This ensures that the path to the fips_enabled fact is available
+    # when `simp config` is run directly after installing a fresh SIMP ISO
+    Facter.search( '/etc/puppet/environments/simp/modules/common/lib/facter' )
+
     # read in answers file
     answers_hash = {}
     if file = @options.fetch( :input_file )


### PR DESCRIPTION
Before this commit, 'simp config' always detected (and suggested)
`use_fips=no` even if FIPS was enabled.  This patch ensures that even
before puppet is run, `simp config` will have access to the
`fips_enabled` fact by adding `common/lib/facter` to the Facter search
path.

NOTE: This fix is naive and direct.  It is intended to address only the
(common) scenario where `simp config` is run on a freshly-installed SIMP
OS.  It will not work if the ISO changes structure or on a non-SIMP OS.

SIMP-497 #close #comment Added direct path to common/lib/facter