### PR TITLE
(SIMP-544) Grub passwords properly replaced during config

### DIFF
--- a/build/rubygem-simp-cli.el6.spec
+++ b/build/rubygem-simp-cli.el6.spec
@@ -16,7 +16,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.7
+Version: 1.0.8
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -88,7 +88,10 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
-* Mon Sep 28 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0-7-0
+* Thu Oct 15 2015 Nick Markowski <nmarkowski@keywcorp.com> - 1.0.8-0
+- Grub passwords are now replaced instead of being amended during config.
+
+* Mon Sep 28 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.7-0
 - Ensure that the puppet digest algorithm is set to sha256 prior if FIPS
   mode is enabled in 'simp config'
 

--- a/build/rubygem-simp-cli.el7.spec
+++ b/build/rubygem-simp-cli.el7.spec
@@ -12,7 +12,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.7
+Version: 1.0.8
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -80,7 +80,10 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
-* Mon Sep 28 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0-7-0
+* Thu Oct 15 2015 Nick Markowski <nmarkowski@keywcorp.com> - 1.0.8-0
+- Grub passwords are now replaced instead of being amended during config.
+
+* Mon Sep 28 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.7-0
 - Ensure that the puppet digest algorithm is set to sha256 prior if FIPS
   mode is enabled in 'simp config'
 

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.7'
+  VERSION = '1.0.8'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/lib/simp/cli/config/item/grub_password.rb
+++ b/lib/simp/cli/config/item/grub_password.rb
@@ -41,7 +41,7 @@ module Simp::Cli::Config
     def apply
       if Facter.value('lsbmajdistrelease') > "6" then
         # TODO: beg team hercules to make a augeas provider for grub2 passwords?
-        `sed -i 's/password_pbkdf2 root/password_pbkdf2 root #{@value}/' /etc/grub.d/01_users`
+        `sed -i 's/password_pbkdf2 root.*$/password_pbkdf2 root #{@value}/' /etc/grub.d/01_users`
         `grub2-mkconfig -o /etc/grub2.cfg`
       else
         `sed -i '/password/ c\password --encrypted #{@value}' /boot/grub/grub.conf`


### PR DESCRIPTION
Grub passwords were being amended in RHEL/CentOS 7.  They are now
properly replaced.

SIMP-544 #close Fix grub passwords