### PR TITLE
(SIMP-551) Make `puppet::autosign` non-interactive

### DIFF
--- a/spec/lib/simp/cli/config/item/files/autosign.conf.new
+++ b/spec/lib/simp/cli/config/item/files/autosign.conf.new
@@ -1,0 +1,11 @@
+#
+# You should place any hostnames/domains here that you wish to autosign.
+# The most security concious method is to list each individual hostname:
+#    hosta.your.domain
+#    hostb.your.domain
+#
+# Wildcard domains work, but absolutely should NOT be used unless you fully
+# trust your network.
+#    *.your.domain
+#
+puppet.your.domain

--- a/spec/lib/simp/cli/config/item/files/autosign.conf.used
+++ b/spec/lib/simp/cli/config/item/files/autosign.conf.used
@@ -1,0 +1,15 @@
+# You should place any hostnames/domains here that you wish to autosign.
+# The most security conscious method is to list each individual hostname:
+#   hosta.your.domain
+#   hostb.your.domain
+#
+# Wildcard domains work, but absolutely should NOT be used unless you fully
+# trust your network.
+#   *.your.domain
+
+# TODO: provide an executable for autosign validation instead of an unvalidated
+#       list of certnames.
+puppet.fake.domain
+server1.fake.domain
+server2.fake.domain
+

--- a/spec/lib/simp/cli/config/item/puppet_autosign_spec.rb
+++ b/spec/lib/simp/cli/config/item/puppet_autosign_spec.rb
@@ -1,30 +1,55 @@
 require 'simp/cli/config/item/puppet_autosign'
+require 'simp/cli/config/item/hostname'
 require 'rspec/its'
 require_relative( 'spec_helper' )
 
 describe Simp::Cli::Config::Item::PuppetAutosign do
   before :each do
-    @ci = Simp::Cli::Config::Item::PuppetAutosign.new
+    @file_dir  = File.expand_path( 'files',  File.dirname( __FILE__ ) )
+    tmp_dir    = File.expand_path( 'tmp',  File.dirname( __FILE__ ) )
+    @tmp_dir   = Dir.mktmpdir(File.basename(__FILE__), tmp_dir )
+    @ci        = Simp::Cli::Config::Item::PuppetAutosign.new
+    @ci.silent = true
+
+    # add hostname to ConfigItems
+    item             = Simp::Cli::Config::Item::Hostname.new
+    item.value       = 'puppet.domain.tld'
+    @ci.config_items[item.key] = item
   end
 
-  describe "#validate" do
-    it "validates array with good autosign entries" do
-      expect( @ci.validate ['10.0.71.1'] ).to eq true
-      expect( @ci.validate ['192.168.1.1', '8.8.8.8'] ).to eq true
-      expect( @ci.validate ['10.0.71.1'] ).to eq true
+  describe "#apply" do
+    it 'persists an existing autosign.conf' do
+      # copy file from files to tmp
+      FileUtils.cp File.join( @file_dir, 'autosign.conf.used'), @tmp_dir
+      @ci.file   = File.join( @tmp_dir, 'autosign.conf.used' )
+      @ci.apply
+      lines = File.readlines( @ci.file ).join( "\n" )
+      expect( lines ).to match(%r{^puppet.fake.domain\n\s*server1.fake.domain\n\s*server2.fake.domain$})
     end
 
-    it "doesn't validate array with bad autosign entries" do
-      expect( @ci.validate 0     ).to eq false
-      expect( @ci.validate nil   ).to eq false
-      expect( @ci.validate false ).to eq false
-      expect( @ci.validate [nil] ).to eq false
-      expect( @ci.validate ['1.2.3'] ).to eq false
-      expect( @ci.validate ['1.2.3.999'] ).to eq false
-      expect( @ci.validate ['8.8.8.8.'] ).to eq false
+    it 'handles a newly-bootstrapped autosign.conf' do
+      # copy file from files to tmp
+      FileUtils.cp File.join( @file_dir, 'autosign.conf.new'), @tmp_dir
+      @ci.file   = File.join( @tmp_dir, 'autosign.conf.new' )
+      @ci.apply
+      lines = File.readlines( @ci.file ).join( "\n" )
+      expect( lines ).to match(%r{^puppet.domain.tld$})
+    end
+
+    it 'handles an empty autosign.conf' do
+      FileUtils.touch File.join( @tmp_dir, 'autosign.conf.empty' )
+      @ci.file   = File.join( @tmp_dir, 'autosign.conf.empty' )
+      @ci.apply
+      lines = File.readlines( @ci.file ).join( "\n" )
+      expect( lines ).to match(%r{^puppet.domain.tld$})
     end
   end
 
+  after :each do
+    FileUtils.remove_entry_secure @tmp_dir
+  end
+
+  it_behaves_like "an Item that doesn't output YAML"
   it_behaves_like "a child of Simp::Cli::Config::Item"
 end
 


### PR DESCRIPTION
Before this patch, `simp config` needlessly queried the user for
the values of `puppet::autosign`.  This commit makes the process
non-interactive, persisiting existing content if there is any, and
adding the puppet server's FQDN when `/etc/puppet/autosign.conf` is
empty or new.

SIMP-551 #close #comment Made `puppet::autosign` non-interactive