### PR TITLE
(SIMP-552) Fail when answerfile does not have item

### DIFF
--- a/lib/simp/cli/config/item.rb
+++ b/lib/simp/cli/config/item.rb
@@ -13,6 +13,7 @@ module Simp::Cli::Config
     attr_accessor :die_on_apply_fail, :allow_user_apply
     attr_accessor :config_items
     attr_accessor :next_items_tree
+    attr_accessor :fail_on_missing_answer
 
     def initialize(key = nil, description = nil)
       @key               = key         # answers file key for the config Item
@@ -26,6 +27,7 @@ module Simp::Cli::Config
       @silent            = false       # no output to stdout/Highline
       @die_on_apply_fail = false       # halt simp config if apply fails
       @allow_user_apply  = false       # allow non-superuser to apply
+      @fail_on_missing_answer = false  # error out if @value is not pre-populated
 
       @config_items      = {}          # a hash of all previous Config::Items
       # a Hash of additional Items that this Item may need to add to the Queue
@@ -103,6 +105,14 @@ module Simp::Cli::Config
     # choose @value of Item
     def query
       extra = query_status
+
+      if @value.nil? && @fail_on_missing_answer
+        say( "<%= color(%q(FATAL: no answer for '), RED) %>" +
+             "<%= color(%q{#{extra}#{@key}}, BOLD,  RED)%>" +
+             "<%= color(%q('; exiting!), RED)%>\n" )
+        exit 1
+      end
+
       if !@skip_query && @value.nil?
         print_banner
         @value = query_ask

--- a/lib/simp/cli/config/item/use_fips.rb
+++ b/lib/simp/cli/config/item/use_fips.rb
@@ -34,8 +34,9 @@ than your security policies allow.
     def apply
       if @value
         # This is a one-off prep item needed to handle Puppet certs w/FIPS mode
-        %x(puppet config set digest_algorithm sha256)
-        $?.success?
+        cmd = %q(puppet config set digest_algorithm sha256)
+        puts cmd unless @silent
+        %x{#{cmd}}
       else
         puts 'not using FIPS mode: noop'
         true # we applied nothing, successfully!

--- a/lib/simp/cli/config/questionnaire.rb
+++ b/lib/simp/cli/config/questionnaire.rb
@@ -18,8 +18,8 @@ class Simp::Cli::Config::Questionnaire
 
   def initialize( options = {} )
     @options = {
-     :noninteractive => INTERACTIVE,
-     :verbose        => 0
+     :noninteractive          => INTERACTIVE,
+     :verbose                 => 0
     }.merge( options )
   end
 
@@ -48,10 +48,15 @@ class Simp::Cli::Config::Questionnaire
   #
   # simp config can run in the following modes:
   #   - interactive (prompt each item)
-  #   - mostly non-interactive (-f; prompt items that can't be inferred)
+  #   - mostly non-interactive (-f/-A; prompt items that can't be inferred)
+  #   - never prompt (-a/-ff);
   #   - never prompt (-ff; relies on cli args for non-inferrable items))
   def process_item item
     item.skip_query = true if @options[ :noninteractive ] >= NONINTERACTIVE
+    if @options.fetch( :fail_on_missing_answers, false )
+      item.fail_on_missing_answer = true
+    end
+
     if @options[ :noninteractive ] == INTERACTIVE
       item.query
     else


### PR DESCRIPTION
Before this commit, `simp config -a ANSWERFILE` would interactively
prompt for any item that did not have an answer in the the ANSWERFILE.
The `--help` documentation hinted that the flag `-ff` would accomplish
this.

This patch adjusts several things:
  - `simp config -a ANSWERFILE` fails when an item has no answer
  - `simp config -A ANSWERFILE` prompts when an an item has no answer
  - The misleading `--help` documentation for `-ff` has been removed
  - The Config::Item `use_fips` now echoes its command unless `@silent`

SIMP-552 #close #comment `simp config -a` fails when Item has no answer
SIMP-552 #close #comment `simp config -A` asks when Item has no answer
SIMP-528 #close #comment removed confusing `-ff` note from `--help`