### PR TITLE
(SIMP-573) Fix broken path logic in `simp doc`

### DIFF
--- a/build/rubygem-simp-cli.el6.spec
+++ b/build/rubygem-simp-cli.el6.spec
@@ -16,11 +16,11 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.8
+Version: 1.0.9
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
-URL: https://github.com/NationalSecurityAgency/rubygem-simp-cli
+URL: https://github.com/simp/rubygem-simp-cli
 Source0: %{gemname}-%{version}.gem
 Requires: ruby(abi) = %{rubyabi}
 Requires: ruby(rubygems)
@@ -34,7 +34,7 @@ Requires: facter => 2.2
 # Requires: rubygem(highline) < 1.7    # error!
 # Requires: rubygem(facter) => 2       # not packaged as rubygem-facter
 # Requires: rubygem(facter) < 3        # not packaged as rubygem-facter
-#Requires: facter < 3                  # error!
+# Requires: facter < 3                 # error!
 BuildRequires: ruby(abi) = %{rubyabi}
 BuildRequires: ruby(rubygems)
 BuildRequires: ruby
@@ -88,6 +88,10 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Fri Oct 30 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.9-0
+- Made 'simp config' item 'puppet::autosign' non-interactive
+- Fixed broken documentation path in 'simp doc'
+
 * Thu Oct 15 2015 Nick Markowski <nmarkowski@keywcorp.com> - 1.0.8-0
 - Grub passwords are now replaced instead of being amended during config.
 

--- a/build/rubygem-simp-cli.el7.spec
+++ b/build/rubygem-simp-cli.el7.spec
@@ -12,7 +12,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.8
+Version: 1.0.9
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -80,6 +80,10 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Fri Oct 30 2015 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.9-0
+- Made 'simp config' item 'puppet::autosign' non-interactive
+- Fixed broken documentation path in 'simp doc'
+
 * Thu Oct 15 2015 Nick Markowski <nmarkowski@keywcorp.com> - 1.0.8-0
 - Grub passwords are now replaced instead of being amended during config.
 

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.8'
+  VERSION = '1.0.9'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/lib/simp/cli/commands/doc.rb
+++ b/lib/simp/cli/commands/doc.rb
@@ -3,7 +3,7 @@ module Simp::Cli::Commands; end
 class Simp::Cli::Commands::Doc < Simp::Cli
   def self.run(args = Array.new)
     raise "Package 'simp-doc' is not installed, cannot continue" unless system("rpm -q --quiet simp-doc")
-    pupdoc = "/usr/share/doc/simp-#{ %x{rpm -q simp-doc | cut -f3 -d'-'}.chomp }/html/index.html"
+    pupdoc = %x{rpm -ql simp-doc | grep html/index.html$ | head -1}.strip.chomp
     raise "Could not find the SIMP documentation. Please ensure that you can access '#{pupdoc}'." unless File.exists?(pupdoc)
     exec("links #{pupdoc}")
   end


### PR DESCRIPTION
Before this commit, running `simp doc` would die with errors because it
was looking in a nonexistent path.

This commit corrects the path-finding logic, re-enabling `simp doc`.

SIMP-573 #close #comment Fixed broken path logic in `simp doc`