### PR TITLE
(SIMP-606) 'simp bootstrap' prints the admin group on apply.

### DIFF
--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -234,7 +234,7 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli
       # At this point, we should be connected to LDAP properly.
       # Run puppet up to 3 additional times if we can't verify that we're actually connected!
       j = 0
-      while (j < 3) && !system('getent group administrators') do
+      while (j < 3) && !system('getent group administrators >& /dev/null') do
         track_output("#{pupcmd}")
         j = j + 1
       end


### PR DESCRIPTION
Pushed output of getent group to /dev/null.

SIMP-606 #close Print admin