### PR TITLE
(SIMP-624) Update `simp config` to use simplib

### DIFF
--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.12'
+  VERSION = '1.0.13'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/lib/simp/cli/config/item/common_runlevel_default.rb
+++ b/lib/simp/cli/config/item/common_runlevel_default.rb
@@ -8,7 +8,7 @@ module Simp::Cli::Config
   class Item::CommonRunLevelDefault < Item
     def initialize
       super
-      @key         = 'common::runlevel'
+      @key         = 'simplib::runlevel'
       @description = %Q{The default system runlevel (1-5).}
     end
 

--- a/lib/simp/cli/config/item/network_conf.rb
+++ b/lib/simp/cli/config/item/network_conf.rb
@@ -40,7 +40,7 @@ module Simp::Cli::Config
         cmd += %Q@ipaddr => '#{ipaddress}', @
         cmd += %Q@netmask => '#{netmask}', @
         cmd += %Q@gateway => '#{gateway}' } @
-        cmd += %Q@class{ 'common::resolv': @
+        cmd += %Q@class{ 'simplib::resolv': @
         cmd += %Q@resolv_domain => '#{resolv_domain}', @
         cmd += %Q@nameservers => #{ format_puppet_array( dns_servers ) }, @
         cmd += %Q@search => #{ format_puppet_array( dns_search ) }, @


### PR DESCRIPTION
This update replaces `common::` references with `simplib::`

SIMP-624 #close