### PR TITLE
(SIMP-661) Fix for the bad simp symlink

### DIFF
--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.14'
+  VERSION = '1.0.15'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -143,7 +143,7 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli
         end
       end
 
-      FileUtils.ln_s('simp','production')
+      FileUtils.ln_s('simp','production') unless File.exist?('production')
     end
 
     linecounts = Array.new


### PR DESCRIPTION
Updated 'simp bootstrap' to ensure that we don't drop a bad symlink at
/etc/puppet/environments/simp/simp

SIMP-661 #close