### PR TITLE
(SIMP-1178) Nail down 'listen' to Ruby < 2.2 safe

### DIFF
--- a/build/rubygem-simp-cli.el6.spec
+++ b/build/rubygem-simp-cli.el6.spec
@@ -16,7 +16,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.16
+Version: 1.0.17
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -88,6 +88,9 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Wed Jun 22 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.17-0
+- Nail 'listen' to a safe version as a runtime dependency for 'guard'
+
 * Tue Feb 02 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.16-0
 - Fixed issue with overwriting pre-existing host certificates during 'simp
   config'

--- a/build/rubygem-simp-cli.el7.spec
+++ b/build/rubygem-simp-cli.el7.spec
@@ -12,7 +12,7 @@
 
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
-Version: 1.0.16
+Version: 1.0.17
 Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
@@ -80,6 +80,9 @@ find %{buildroot}%{geminstdir}/bin -type f | xargs chmod a+x
 
 
 %changelog
+* Wed Jun 22 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.17-0
+- Nail 'listen' to a safe version as a runtime dependency for 'guard'
+
 * Tue Feb 02 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.16-0
 - Fixed issue with overwriting pre-existing host certificates during 'simp
   config'

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.16'
+  VERSION = '1.0.17'
 
   require 'optparse'
   require 'simp/cli/lib/utils'

--- a/simp-cli.gemspec
+++ b/simp-cli.gemspec
@@ -53,6 +53,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake',        '~> 10'
   s.add_development_dependency 'rspec',       '~> 3'
   s.add_development_dependency 'rspec-its',   '~> 1'
+  s.add_development_dependency 'listen',      '~> 3.0.0'
   s.add_development_dependency 'guard',       '~> 2'
   s.add_development_dependency 'guard-shell', '~> 0'
   s.add_development_dependency 'guard-rspec', '~> 4'


### PR DESCRIPTION
Guard requires listen as a runtime dependency so we needed to nail it
down to something that was Ruby < 2.2 safe.

SIMP-1178 #comment Vestige in this gem