### PR TITLE
(SIMP-1199) Fix `simp passgen`

### DIFF
--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -5,7 +5,7 @@ module Simp; end
 
 # namespace for SIMP CLI commands
 class Simp::Cli
-  VERSION = '1.0.17'
+  VERSION = '1.0.18'
 
   require 'optparse'
   require 'simp/cli/lib/utils'


### PR DESCRIPTION
This update fixes the `simp passgen` command to work with the default
SIMP environment location.

It now attempts to detect the environment when called using 'puppet
config print environmentpath'

SIMP-1199 #close