### PR TITLE
(SIMP-1299) Fix broken simp command line parsing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
     - sudo apt-get install -y libcrack2
 
 rvm:
-  - 1.9.3
   - 2.0.0
+  - 2.1.0
 
 env:
   - SIMP_SKIP_NON_SIMPOS_TESTS=1

--- a/lib/simp/cli/commands/passgen.rb
+++ b/lib/simp/cli/commands/passgen.rb
@@ -20,7 +20,7 @@ class Simp::Cli::Commands::Passgen < Simp::Cli
       @target_dir = dir
     end
 
-    opts.on("-l", "--list", "List possible usernames upon whic to operate") do
+    opts.on("-l", "--list", "List possible usernames upon which to operate") do
       @show_list = true
     end
 
@@ -41,6 +41,13 @@ class Simp::Cli::Commands::Passgen < Simp::Cli
       exit 0
     end
 
+   end
+
+  def self.run(args = Array.new)
+    super
+
+    raise "The SIMP Passgen Tool requires at least one argument to work" if args.empty?
+
     unless @target_dir
       env_path = %x(puppet config print environmentpath).strip
       if File.directory?(env_path)
@@ -49,12 +56,7 @@ class Simp::Cli::Commands::Passgen < Simp::Cli
         raise(OptionParser::ParseError, 'Could not find a target passgen directory, please specify one with the `-d` option')
       end
     end
-  end
 
-  def self.run(args = Array.new)
-    super
-
-    raise "The SIMP Passgen Tool requires at least one argument to work" if args.empty?
     raise "Target directory '#{@target_dir}' does not exist" unless File.directory?(@target_dir)
 
     begin

--- a/lib/simp/cli/config/item/sssd_domains.rb
+++ b/lib/simp/cli/config/item/sssd_domains.rb
@@ -12,7 +12,7 @@ module Simp::Cli::Config
       @key         = 'sssd::domains'
       @description = %Q{
         A list of domains for SSSD to use.
-        `simp config` will automativcally populate this field with `FQDN` if
+        `simp config` will automatically populate this field with `FQDN` if
         `use_fqdn` is true, otherwise it will comment out the field.
       }.gsub(/^\s+/, '' )
     end

--- a/spec/lib/simp/cli/commands/passgen_spec.rb
+++ b/spec/lib/simp/cli/commands/passgen_spec.rb
@@ -1,0 +1,13 @@
+require 'simp/cli/commands/passgen'
+require_relative( '../spec_helper' )
+
+
+describe Simp::Cli::Commands::Passgen do
+  describe ".run" do
+    it "requires valid target passgen dir" do
+      expect { Simp::Cli::Commands::Passgen.run([]) }.to raise_error(RuntimeError)
+      expect { Simp::Cli::Commands::Passgen.run(['-l']) }.to raise_error(RuntimeError)
+      expect { Simp::Cli::Commands::Passgen.run(['-d', '/oops']) }.to raise_error(OptionParser::ParseError)
+    end
+  end
+end


### PR DESCRIPTION
Moved validation of passgen command line args to after the command
line has been parsed.

SIMP-1299 #close
