### PR TITLE
(SIMP-1725) spec tests fail due to SIMP6 updates

### DIFF
--- a/bin/simp
+++ b/bin/simp
@@ -16,9 +16,9 @@ Gem.path.unshift(File.expand_path(File.join(File.dirname(__FILE__), '../../..'))
 # Having extra, or missing, libraries in the Fact path doesn't hurt anything.
 fact_paths = [
   %(/usr/share/simp/modules/stdlib/lib/facter),
-  %(/usr/share/simp/modules/simplib/lib/facter),
-  ENV['FACTER_PATH']
+  %(/usr/share/simp/modules/simplib/lib/facter)
 ]
+fact_paths << ENV['FACTER_PATH'] unless ENV['FACTER_PATH'].nil? or ENV['FACTER_PATH'].empty?
 
 require 'rubygems'
 require 'simp/cli'

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 1.0.21
+%global cli_version 1.0.23
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up
@@ -97,6 +97,9 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Thu Oct 20 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.23-0
+- Fix minor bug causing spec tests to fail
+
 * Sat Oct 01 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.22-0
 - Changes made to support both SIMP 6 and legacy versions.
 - Bundled in highline

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,6 +1,6 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '1.0.21'
+  VERSION = '1.0.23'
 end
 


### PR DESCRIPTION
Fixed logic that broke spec tests.
Upped the patch version by 2 to fix the inconsistent versioning
in the RPM header and changelog sections of the spec file.

SIMP-1725 #close