### PR TITLE
(SIMP-1864) Fix for the Rakefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 /.rspec_system
 /.bundle
 /vendor
-/Gemfile.lock
+Gemfile.lock
 spec/lib/simp/cli/config/item/tmp/

--- a/Rakefile
+++ b/Rakefile
@@ -95,6 +95,6 @@ namespace :pkg do
     end
   end
 
-  task :rpm => [:gem]
+  Rake::Task[:rpm].prerequisites.unshift(:gem)
 end
 # vim: syntax=ruby


### PR DESCRIPTION
The :rpm task needed to have :gem prepended to the list of task
prerequisites instead of the usual append.

SIMP-1864 #close

Change-Id: Iee18f6284fc48744385e4fd810b76b153790944e