### PR TITLE
(SIMP-2255) Remove `--pluginsync` from bootstrap

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -97,6 +97,9 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Mon Dec 05 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 1.0.24-0
+- Suppress `--pluginsync` unless Puppet version is `3.x`
+
 * Thu Oct 20 2016 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.23-0
 - Fix minor bug causing spec tests to fail
 

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -152,8 +152,13 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli
     FileUtils.mkpath(File.dirname(logfilepath)) unless File.exists?(logfilepath)
     @logfile = File.open(logfilepath, 'w')
 
+    puppet_major_version = `puppet --version`.chomp.split('.').first
     # Define the puppet command call and the run command options
-    pupcmd = 'puppet agent --pluginsync --onetime --no-daemonize --no-show_diff --verbose --no-splay --masterport=8150 --ca_port=8150'
+    pupcmd = 'puppet agent --onetime --no-daemonize --no-show_diff --verbose --no-splay --masterport=8150 --ca_port=8150'
+    if puppet_major_version == '3'
+      pupcmd += " --pluginsync"
+    end
+
     pupruns = [
       'pki,stunnel,concat',
       'firstrun,concat',
@@ -228,7 +233,10 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli
 
     # From this point on, run puppet without specifying the masterport since
     # puppetserver is configured.
-    pupcmd = "puppet agent --pluginsync --onetime --no-daemonize --no-show_diff --verbose --no-splay"
+    pupcmd = "puppet agent --onetime --no-daemonize --no-show_diff --verbose --no-splay"
+    if puppet_major_version == '3'
+      pupcmd += " --pluginsync"
+    end
 
     # Run puppet agent up to 3X to get slapd running (unless it already is)
     # If this fails, LDAP is probably not configured right

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,6 +1,6 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '1.0.23'
+  VERSION = '1.0.24'
 end
 


### PR DESCRIPTION
Before this patch, `simp bootstrap` would print deprecation warnings
about the deprecated setting `pluginsync` when run with Puppet 4.x.
This commit fixes the issue by removing the hard-coded `--pluginsync`
arguments from bootstrap's `puppet agent` command strings.

SIMP-2255 #close