### PR TITLE
(SIMP-2255) Correct cli_version in `.spec` file

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 1.0.23
+%global cli_version 1.0.24
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up


### PR DESCRIPTION
This patch bumps the global macro `cli_version` in the RPM spec file, so
RPM builds look for the correct gem.

SIMP-2255 #comment Corrected cli_version in `.spec` file