### PR TITLE
(SIMP-2795) Bad network restart for static config

### DIFF
--- a/lib/simp/cli/config/items/action/configure_network_action.rb
+++ b/lib/simp/cli/config/items/action/configure_network_action.rb
@@ -17,10 +17,10 @@ module Simp::Cli::Config
       ci  = {}
       cmd = nil
 
-      dhcp      = get_item( 'cli::network::dhcp'        ).value
+      dhcp      = get_item( 'cli::network::dhcp' ).value
       # BOOTPROTO=none is valid to spec; BOOTPROTO=static isn't
       bootproto = (dhcp == 'static') ? 'none' : dhcp
-      @interface = get_item( 'cli::network::interface'   ).value
+      @interface = get_item( 'cli::network::interface' ).value
 
       # apply the interface using the SIMP classes
       # NOTE: the "FACTER_ipaddress=XXX" helps puppet avoid a fatal error that

--- a/lib/simp/cli/config/items/action/set_hostname_action.rb
+++ b/lib/simp/cli/config/items/action/set_hostname_action.rb
@@ -36,13 +36,9 @@ module Simp::Cli::Config
         end
       end
 
-      if success
+      if success && ( get_item( 'cli::network::dhcp' ).value == 'dhcp' )
         # restart the interface to pick up any domain changes associated
-        # with the new hostname
-        # NOTE:  This operation is really for the DCHP configuration case
-        # in which we have already configured the network, but it doesn't
-        # hurt to restart the interface for the static configuration case,
-        # as well.
+        # with the new hostname, if the interface is configured via DHCP
         interface = get_item( 'cli::network::interface' ).value
         debug( "Restarting #{interface} interface to update domain info" )
         show_wait_spinner {

--- a/lib/simp/cli/config/items/data/cli_network_dhcp.rb
+++ b/lib/simp/cli/config/items/data/cli_network_dhcp.rb
@@ -16,7 +16,7 @@ module Simp::Cli::Config
     end
 
     def validate( x )
-      return ['dhcp', 'static' ].include?( x.to_s.downcase )
+      return ['dhcp', 'static' ].include?( x.to_s )
     end
 
     def not_valid_message

--- a/spec/lib/simp/cli/config/items/data/cli_network_dhcp_spec.rb
+++ b/spec/lib/simp/cli/config/items/data/cli_network_dhcp_spec.rb
@@ -10,9 +10,7 @@ describe Simp::Cli::Config::Item::CliNetworkDHCP do
   describe "#validate" do
     it "validates dhcp/static" do
       expect( @ci.validate('dhcp') ).to eq true
-      expect( @ci.validate('DHCP') ).to eq true
       expect( @ci.validate('static') ).to eq true
-      expect( @ci.validate('STATIC') ).to eq true
     end
 
     it "doesn't validate other things" do


### PR DESCRIPTION
Only restart the network after the hostname is set, when
the network is configured via DHCP.

SIMP-2795 #close