### PR TITLE
(SIMP-2990) Fix simp bootstrap instructions

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -97,6 +97,13 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Thu Apr 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.0
+- simp bootstrap update:
+  - Tweak post-bootstrap text to remove instructions to run
+    puppet and to make it more clear that the user must reboot.
+  - Do not tell user existing certificates have been preserved,
+    when none exist.
+
 * Tue Apr 04 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.0
 - simp bootstrap update:
   - Minor tweak to ssldir removal logic and messages

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -146,7 +146,10 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli
       warn('Warning: Primitive checks indicate there may have been issues', 'magenta')
     end
     info("#{@logfile.path} contains details of the bootstrap actions performed.", 'yellow')
-    info('You must reboot your system to complete the bootstrap process.', 'magenta.bold')
+    info('Prior to operation, you must reboot your system.', 'magenta.bold')
+    info('Run `puppet agent -t` after reboot to complete the bootstrap process.', 'magenta.bold')
+    info('It may take a few minutes before the puppetserver accepts agent', 'magenta.bold')
+    info('connections after boot.', 'magenta.bold')
 
     # Re-enable the non-bootstrap puppet agent
     execute('puppet agent --enable')


### PR DESCRIPTION
- Tweak post-bootstrap text to remove instructions to run
  puppet and to make it more clear that the user must reboot
  to complete the bootstrap process.
- Do not tell user existing certificates have been preserved,
  when none exist.

SIMP-2990 #close