### PR TITLE
WIP: (SIMP-2838) Add kv subcommand to simp-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /.rspec_system
 /.bundle
 /vendor
+/modules
 Gemfile.lock
 spec/lib/simp/cli/config/item/tmp/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,26 @@
+#
+---
+unit-test-ruby-2.1:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.1
+  script:
+    - bundle install
+    - bundle exec rake spec
+unit-test-ruby-2.2:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.2
+  script:
+    - bundle install
+    - bundle exec rake spec
+unit-test-ruby-2.3:
+  stage: test
+  tags:
+    - docker
+  image: ruby:2.3
+  script:
+    - bundle install
+    - bundle exec rake spec

--- a/Gemfile
+++ b/Gemfile
@@ -47,7 +47,7 @@ group :development do
   # enhanced REPL + debugging environment
   gem 'pry'
   gem 'pry-doc'
-
+  gem 'pry-byebug'
   # Automatically test changes
   gem 'guard'
   gem 'guard-shell'

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -4,6 +4,7 @@ require 'optparse'
 
 require 'simp/cli/version'
 require 'simp/cli/lib/utils'
+require 'simp/cli/lib/libkv'
 
 # load each command
 commands_path = File.expand_path( 'cli/commands/*.rb', File.dirname(__FILE__) )
@@ -34,7 +35,7 @@ class Simp::Cli
   end
 
   def self.run(args)
-    @opt_parser.parse!(args)
+     @opt_parser.parse!(args)
   end
 
   private

--- a/lib/simp/cli/commands/kv.rb
+++ b/lib/simp/cli/commands/kv.rb
@@ -1,0 +1,60 @@
+# vim: set expandtab ts=2 sw=2:
+require File.expand_path( '../../cli', File.dirname(__FILE__) )
+
+module Simp::Cli::Commands; end
+class Simp::Cli::Commands::KV < Simp::Cli
+
+  @url = "mock:///"
+
+  @opt_parser = OptionParser.new do |opts|
+    opts.banner = "\nSIMP KV Tool"
+    opts.separator ""
+    opts.separator "The SIMP KV Tool provides an api for accessing the libkv backend in a puppet environment."
+    opts.separator ""
+    opts.separator "OPTIONS:\n"
+
+    opts.on("-x", "--url URL", "Libkv url to use") do |url|
+      @url = url
+    end
+   end
+  def self.run(args = Array.new)
+    super
+    subcommand = args.shift
+    if (subcommand == nil)
+
+    else
+      libkv = Simp::Libkv.new(@url)
+      case subcommand
+      when "create"
+        params = {}
+        params["key"] = args.shift
+        params["value"] = args.shift
+        puts libkv.atomic_create(params)
+      when "put"
+        params = {}
+        params["key"] = args.shift
+        params["value"] = args.shift
+        puts libkv.put(params)
+      when "get"
+        params = {}
+        params["key"] = args.shift
+        puts libkv.get(params)
+      when "delete"
+        params = {}
+        params["key"] = args.shift
+        puts libkv.delete(params)
+      when "list"
+        params = {}
+        params["key"] = args.shift
+        puts libkv.list(params)
+      end
+    end
+  end
+
+  # Resets options to original values.
+  # This ugly method is needed for unit-testing, in which multiple occurrences of
+  # the self.run method are called with different options.
+  # FIXME Variables set here are really class variables, not instance variables.
+  def self.reset_options
+  end
+end

--- a/lib/simp/cli/lib/libkv.rb
+++ b/lib/simp/cli/lib/libkv.rb
@@ -1,0 +1,17 @@
+# vim: set expandtab ts=2 sw=2:
+module Simp; end
+require_relative 'utils.rb'
+require 'pry'
+class Simp::Libkv
+  def initialize(url = nil)
+    if (url == nil)
+    # XXX Todo: Get url from puppet lookup
+    end
+    @url = url
+    @auth = {}
+    @libkv_code, @loader_filename = ::Utils.load_code_from_puppet("libkv", ["puppet_x/libkv/libkv.rb"])
+  end
+  def method_missing(symbol, *args, &block)
+    @libkv_code.send(symbol, @url, @auth, *args, &block)
+  end
+end

--- a/lib/simp/cli/lib/utils.rb
+++ b/lib/simp/cli/lib/utils.rb
@@ -143,8 +143,39 @@ module Utils
     end
     value
   end
-
   def valid_ip?(value)
     value.to_s =~ /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/
   end
+  def load_code_from_puppet(modulename, loaderpaths)
+    paths = [
+      "modules/#{modulename}/lib",
+      "#{::Utils.puppet_info[:environment_path]}/modules/#{modulename}/lib",
+      "/opt/puppetlabs/puppet/cache/lib",
+      "/usr/share/simp/modules/#{modulename}/lib",
+    ] + $LOAD_PATH
+    found_code = false
+    code = Object.new()
+    loader_filename = ""
+    paths.each do |path|
+      if (Dir.exists?(path))
+          loaderpaths.each do |loader|
+            loader_filename = "#{path}/#{loader}"
+            if (File.exists?(loader_filename))
+              found_code = true
+              code.instance_eval(File.read(loader_filename), loader_filename)
+              break
+            end
+          end
+          if (found_code)
+            break
+          end
+      end
+    end
+    if (found_code)
+      return code, loader_filename
+    else
+      return nil, ""
+    end
+  end
+
 end

--- a/spec/lib/simp/cli_spec.rb
+++ b/spec/lib/simp/cli_spec.rb
@@ -19,6 +19,7 @@ describe "Simp::Cli" do
                  "    - bootstrap\n" +
                  "    - config\n" +
                  "    - doc\n" +
+		 "    - kv\n" +
                  "    - passgen\n" +
                  "    - version\n" +
                  "    - help [command]\n\n"


### PR DESCRIPTION
This adds a kv subcommand to simp-cli, that dydnamically
loads libkv from either:
  1. local path (modules/libkv)
  2. Puppet environment (/etc/puppetlabs/code/environments/#{environment}/modules/libkv)
  3. Puppet agent cache (/opt/puppetlabs/puppet/cache/)
  4. or a rubgem location in $LOAD_PATH.

It then creates a wrapper object that provides the same ruby api as the
libkv module, and exposes this to subcommands.

The following five subcommands are implemented:
  * get
  * put
  * list
  * delete
  * create