### PR TITLE
(SIMP-3210) Remove pipes from spawned processes

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 4.0.0
+%global cli_version 4.0.1
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up
@@ -97,6 +97,17 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Mon May 22 2017 Nick Markowski <nmarkowski@keywcorp.com> - 4.0.1
+- simp config update:
+  - We noticed inconsistent behavior when spawning commands with
+    pipes, particularly a pipe to xargs.  Item execute has been
+    re-tooled to reject pipes, and provide users with a way to
+    chain commands while mitigating code flux due to change in API.
+  - Added the run_command method to Cli::Config::Item
+  - Action items updated:
+    - update_os_yum_repositories_action
+    - check_server_yum_config_action
+
 * Thu Apr 06 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.0
 - simp bootstrap update:
   - Tweak post-bootstrap text to remove instructions to run
@@ -123,7 +134,7 @@ EOM
     from running, until the operator manually verifies the
     problem has been addressed/is not an issue.
   - Update location to FakeCA
-  
+
 * Mon Mar 27 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.0
 - simp config updates:
   - Add query for svckill::mode to simp scenario

--- a/lib/simp/cli/config/errors.rb
+++ b/lib/simp/cli/config/errors.rb
@@ -16,6 +16,13 @@ module Simp::Cli::Config
     end
   end
 
+  # Invalid spawn command
+  class InvalidSpawnError < InternalError;
+    def initialize(cmd)
+      super("Invalid pipe '|' in spawn command: <#{cmd}>")
+    end
+  end
+
   class PasswordError < StandardError; end
 
 end

--- a/lib/simp/cli/config/items/action/check_server_yum_config_action.rb
+++ b/lib/simp/cli/config/items/action/check_server_yum_config_action.rb
@@ -43,9 +43,11 @@ DOC
       # up, but we have no way to verify that the listed repository
       # is the intended repository.
       result = show_wait_spinner {
-        query_result = execute('repoquery -i kernel | grep ^Repository')
-        query_result = query_result && execute('repoquery -i simp | grep ^Repository')
-        query_result = query_result && execute('repoquery -i puppet-agent | grep ^Repository')
+        query_result = true
+        ['kernel', 'simp', 'puppet-agent'].each do |pkg|
+          query = run_command("repoquery -i #{pkg}")[:stdout].strip
+          query_result = false if not query =~ /^Repository/
+        end
         query_result
       }
 

--- a/lib/simp/cli/config/items/action/update_os_yum_repositories_action.rb
+++ b/lib/simp/cli/config/items/action/update_os_yum_repositories_action.rb
@@ -63,8 +63,10 @@ module Simp::Cli::Config
             debug( "Disabling CentOS repositories in #{@yum_repos_d}" )
             # Don't use pipes with spawn
             repos = run_command(%q{grep "\\[*\\]" *CentOS*.repo})[:stdout].strip.split("\n")
-            repos.map { |repo| repo.split(':[').last.tr(']','')}.each do |repo_name|
-              execute("yum-config-manager --disable #{repo_name}")
+            repos.map { |repo|
+              next if not repo =~ /:\[.*\]$/
+              repo.split(':[').last.tr(']','')}.each do |repo_name|
+                execute("yum-config-manager --disable #{repo_name}") if not repo_name.nil?
             end
             debug( "Finished disabling CentOS repositories" )
           end

--- a/lib/simp/cli/config/items/action/update_os_yum_repositories_action.rb
+++ b/lib/simp/cli/config/items/action/update_os_yum_repositories_action.rb
@@ -61,7 +61,11 @@ module Simp::Cli::Config
           # disable any CentOS repo spam
           if ! Dir.glob('CentOS*.repo').empty?
             debug( "Disabling CentOS repositories in #{@yum_repos_d}" )
-            execute( %q{grep "\\[*\\]" *CentOS*.repo | cut -d "[" -f2 | cut -d "]" -f1 | xargs yum-config-manager --disable} )
+            # Don't use pipes with spawn
+            repos = run_command(%q{grep "\\[*\\]" *CentOS*.repo})[:stdout].strip.split("\n")
+            repos.map { |repo| repo.split(':[').last.tr(']','')}.each do |repo_name|
+              execute("yum-config-manager --disable #{repo_name}")
+            end
             debug( "Finished disabling CentOS repositories" )
           end
         end

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '4.0.0'
+  VERSION = '4.0.1'
 end

--- a/spec/lib/simp/cli/config/items/action/check_server_yum_config_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/check_server_yum_config_action_spec.rb
@@ -19,17 +19,17 @@ describe Simp::Cli::Config::Item::CheckServerYumConfigAction do
     end
 
     it "succeeds when all repos are found by repoquery" do
-      allow(@ci).to receive(:execute).with('repoquery -i kernel | grep ^Repository').and_return(true)
-      allow(@ci).to receive(:execute).with('repoquery -i simp | grep ^Repository').and_return(true)
-      allow(@ci).to receive(:execute).with('repoquery -i puppet-agent | grep ^Repository').and_return(true)
+      allow(@ci).to receive(:run_command).with('repoquery -i kernel').and_return({:stdout => 'Repository:'})
+      allow(@ci).to receive(:run_command).with('repoquery -i simp').and_return({:stdout => 'Repository:'})
+      allow(@ci).to receive(:run_command).with('repoquery -i puppet-agent').and_return({:stdout => 'Repository:'})
       @ci.apply
       expect( @ci.applied_status ).to eq :succeeded
     end
 
     it "writes warning file when OS repo is not found by repoquery" do
-      allow(@ci).to receive(:execute).with('repoquery -i kernel | grep ^Repository').and_return(false)
-      allow(@ci).to receive(:execute).with('repoquery -i simp | grep ^Repository').and_return(true)
-      allow(@ci).to receive(:execute).with('repoquery -i puppet-agent | grep ^Repository').and_return(true)
+      allow(@ci).to receive(:run_command).with('repoquery -i kernel').and_return({:stdout => ''})
+      allow(@ci).to receive(:run_command).with('repoquery -i simp').and_return({:stdout => 'Repository:'})
+      allow(@ci).to receive(:run_command).with('repoquery -i puppet-agent').and_return({:stdout => 'Repository:'})
       @ci.apply
       expect( @ci.applied_status ).to eq :failed
       expect( File.exist?(@warning_file) ).to eq true
@@ -37,33 +37,33 @@ describe Simp::Cli::Config::Item::CheckServerYumConfigAction do
       expect( actual_message).to eq @ci.warning_message
       expected_summary =
         "Your SIMP server's YUM configuration may be incomplete.  Verify you have set up\n" +
-        "\tOS updates, SIMP and SIMP dependencies repositories before running\n" + 
+        "\tOS updates, SIMP and SIMP dependencies repositories before running\n" +
         "\t'simp bootstrap'."
       expect( @ci.apply_summary ).to eq expected_summary
     end
 
     it "writes warning file when SIMP repo is not found by repoquery" do
-      allow(@ci).to receive(:execute).with('repoquery -i kernel | grep ^Repository').and_return(true)
-      allow(@ci).to receive(:execute).with('repoquery -i simp | grep ^Repository').and_return(false)
-      allow(@ci).to receive(:execute).with('repoquery -i puppet-agent | grep ^Repository').and_return(true)
+      allow(@ci).to receive(:run_command).with('repoquery -i kernel').and_return({:stdout => 'Repository:'})
+      allow(@ci).to receive(:run_command).with('repoquery -i simp').and_return({:stdout => ''})
+      allow(@ci).to receive(:run_command).with('repoquery -i puppet-agent').and_return({:stdout => 'Repository:'})
       @ci.apply
       expect( @ci.applied_status ).to eq :failed
       expect( File.exist?(@warning_file) ).to eq true
     end
 
     it "writes warning file when SIMP dependencies repo is not found by repoquery" do
-      allow(@ci).to receive(:execute).with('repoquery -i kernel | grep ^Repository').and_return(true)
-      allow(@ci).to receive(:execute).with('repoquery -i simp | grep ^Repository').and_return(true)
-      allow(@ci).to receive(:execute).with('repoquery -i puppet-agent | grep ^Repository').and_return(false)
+      allow(@ci).to receive(:run_command).with('repoquery -i kernel').and_return({:stdout => 'Repository:'})
+      allow(@ci).to receive(:run_command).with('repoquery -i simp').and_return({:stdout => 'Repository:'})
+      allow(@ci).to receive(:run_command).with('repoquery -i puppet-agent').and_return({:stdout => ''})
       @ci.apply
       expect( @ci.applied_status ).to eq :failed
       expect( File.exist?(@warning_file) ).to eq true
     end
 
     it 'appends to warning file' do
-      allow(@ci).to receive(:execute).with('repoquery -i kernel | grep ^Repository').and_return(true)
-      allow(@ci).to receive(:execute).with('repoquery -i simp | grep ^Repository').and_return(false)
-      allow(@ci).to receive(:execute).with('repoquery -i puppet-agent | grep ^Repository').and_return(false)
+      allow(@ci).to receive(:run_command).with('repoquery -i kernel').and_return({:stdout => 'Repository:'})
+      allow(@ci).to receive(:run_command).with('repoquery -i simp').and_return({:stdout => ''})
+      allow(@ci).to receive(:run_command).with('repoquery -i puppet-agent').and_return({:stdout => ''})
       FileUtils.mkdir_p(File.dirname(@warning_file))
       other_warning = "SOME OTHER WARNING"
       File.open(@warning_file, 'w') {|f| f.puts other_warning }

--- a/spec/lib/simp/cli/config/items/item_spec.rb
+++ b/spec/lib/simp/cli/config/items/item_spec.rb
@@ -80,14 +80,14 @@ describe Simp::Cli::Config::Item do
       command = 'ls /some/missing/path1 /some/missing/path2'
       expect( @ci.run_command(command)[:status] ).to eq false
       expect( @ci.run_command(command)[:stdout] ).to match ""
-      expect( @ci.run_command(command)[:stderr] ).to match /ls: cannot access '\/some\/missing\/path1': No such file or directory/
+      expect( @ci.run_command(command)[:stderr] ).to match /ls: cannot access.*\/some\/missing\/path1.*: No such file or directory/
     end
 
     it 'returns true when command fails and ignore_failure is true' do
       command = 'ls /some/missing/path1 /some/missing/path2'
       expect( @ci.run_command(command, true)[:status] ).to eq true
       expect( @ci.run_command(command)[:stdout] ).to match ""
-      expect( @ci.run_command(command)[:stderr] ).to match /ls: cannot access '\/some\/missing\/path1': No such file or directory/
+      expect( @ci.run_command(command)[:stderr] ).to match /ls: cannot access.*\/some\/missing\/path1.*: No such file or directory/
     end
   end
 

--- a/spec/lib/simp/cli/config/items/item_spec.rb
+++ b/spec/lib/simp/cli/config/items/item_spec.rb
@@ -63,7 +63,40 @@ describe Simp::Cli::Config::Item do
     end
   end
 
+  describe "#run_command" do
+    it 'should reject pipes' do
+      command = "ls /some/missing/path1 | grep path1"
+      expect{ @ci.run_command(command) }.to raise_error("Internal error: Invalid pipe '|' in spawn command: <ls /some/missing/path1 | grep path1>")
+    end
+
+    it 'returns true when command succeeeds' do
+      command = "ls #{__FILE__}"
+      expect( @ci.run_command(command)[:status] ).to eq true
+      expect( @ci.run_command(command)[:stdout] ).to match "#{__FILE__}"
+      expect( @ci.run_command(command)[:stderr] ).to eq ""
+    end
+
+    it 'returns false when command fails and ignore_failure is false' do
+      command = 'ls /some/missing/path1 /some/missing/path2'
+      expect( @ci.run_command(command)[:status] ).to eq false
+      expect( @ci.run_command(command)[:stdout] ).to match ""
+      expect( @ci.run_command(command)[:stderr] ).to match /ls: cannot access '\/some\/missing\/path1': No such file or directory/
+    end
+
+    it 'returns true when command fails and ignore_failure is true' do
+      command = 'ls /some/missing/path1 /some/missing/path2'
+      expect( @ci.run_command(command, true)[:status] ).to eq true
+      expect( @ci.run_command(command)[:stdout] ).to match ""
+      expect( @ci.run_command(command)[:stderr] ).to match /ls: cannot access '\/some\/missing\/path1': No such file or directory/
+    end
+  end
+
   describe "#execute" do
+    it 'should reject pipes' do
+      command = "ls /some/missing/path1 | grep path1"
+      expect{ @ci.run_command(command) }.to raise_error("Internal error: Invalid pipe '|' in spawn command: <ls /some/missing/path1 | grep path1>")
+    end
+
     it 'returns true when command succeeeds' do
       command = "ls #{__FILE__}"
       expect( @ci.execute(command) ).to eq true


### PR DESCRIPTION
- simp config update:
  - We noticed inconsistent behavior when spawning commands with
    pipes, particularly a pipe to xargs.  Item execute has been
    re-tooled to reject pipes, and provide users with a way to
    chain commands while mitigating code flux due to change in API.
  - Added the run_command method to Cli::Config::Item
  - Action items updated:
    - update_os_yum_repositories_action
    - check_server_yum_config_action

SIMP-3210 #close