### PR TITLE
(SIMP-3851) Fix missing rubygem error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -78,7 +78,10 @@ namespace :pkg do
       Dir.chdir gem_dir do
         Dir['*.gemspec'].each do |spec_file|
           cmd = %Q{SIMP_RPM_BUILD=1 bundle exec gem build "#{spec_file}" &> /dev/null}
-          sh cmd
+          ::Bundler.with_clean_env do
+            %x{bundle install}
+            sh cmd
+          end
           FileUtils.mkdir_p 'dist'
           FileUtils.mv Dir.glob('*.gem'), File.join(@rakefile_dir, 'dist')
         end

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 4.0.3
+%global cli_version 4.0.4
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up
@@ -67,6 +67,9 @@ mkdir -p %{buildroot}/%{_bindir} # NOTE: this is needed for el7
 gem install --local --install-dir %{buildroot}/%{gemdir} --force %{SOURCE1}
 
 cd ext/gems/highline
+if [ `which bundle 2>/dev/null` ]; then
+  bundle install
+fi
 gem install --local --install-dir %{buildroot}/%{gemdir} --force %{SOURCE11}
 cd -
 
@@ -97,6 +100,9 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Mon Oct 16 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.4
+- Fix intermittent failure in RPM builds due to missing rubygems
+
 * Thu Aug 31 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.3
 - Fix bug in hostname validation that prevented complex hostnames
   such as 'xyz-w-puppet.qrst-a1-b2' to fail validation.


### PR DESCRIPTION
This fixes an intermittent error where missing rubygems would cause the
RPM build to fail.

SIMP-3851 #close