### PR TITLE
(SIMP-4376) SIMP configuration of svckill::mode confusing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,46 +1,59 @@
 ---
 language: ruby
 cache: bundler
+sudo: false
+
+bundler_args: --without development system_tests --path .vendor
+
 notifications:
   email: false
 
-# to provide the cracklib-check and openssl executables
-# NOTE:  Comment out the sudo and before_install keys when running locally,
-#        unless you are running on an ubuntu machine
-#
-# TODO:  Can we use run in TravisCI container environments, instead of standard
-#        environments, if we use the addon.apt.packages key?
-#        May need to get libcrack2  on the approved package whitelist.
-sudo: required
+addons:
+  apt:
+    packages:
+      - rpm
+      - cracklib-runtime
+      - openssl
+
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y libcrack2
-  - sudo apt-get install -y openssl
+  - rm -f Gemfile.lock
 
-# Test with Ruby packaged with Puppet All-in-one install
-rvm:
-  - 2.1.9
-
-# travish requires env.global key
-env:
-  global:
-    - SIMP_SKIP_NON_SIMPOS_TESTS=1
-
-script:
-  - 'bundle exec rake spec'
-
-before_deploy:
-  - bundle exec rake clobber
-  - "export GEM_VERSION=`ruby -r ./lib/simp/cli/version.rb -e 'puts Simp::Cli::VERSION'`"
-  - '[[ $TRAVIS_TAG =~ ^${GEM_VERSION}$ ]]'
-deploy:
-  - provider: releases
-    api_key:
-      secure: "R6KNY9wDFtWVDXA0tC/We+OunS+8wiu4YHymDh5NBO/NWm0Dt5I6+Ado8QfjW5jZWja0Bl1cpjsf65Ln+XMQ6MDsiRvidnqMKTyyzjF/Y5U1inRm6i2+XGCCxKPGVJY6IrSidJg0NIlqKKghaq7DYDT5cDopcA/xHqY/S4mxvJf1OQQ7JdN0GtOrNv2h+lL9qlpvE8ogvb0fQyZXyKkz3TCCyauzb2w6ay4TjIqD2yo8yy3nUInyRDJf6XIyxWdiOFNHe3cwiYblqmosPUMYBf6qkzGPzmsQsmPoqN0+WopMnaNShPoiVoTdXIJDPe0deWmFbvFUvYL1zYoxZ+Vggjd+wXXJBiB3i/7xC3MOj9EPDQtY4AdjG5ZM6mqyjX7jFzv31DfK8WPa11OhDeOYgWfTc8b3MkeDWsKqC/IjPs83M8Qz03Fwxtocx0cNP2BmIDxxMi8GRT45CG3BYONVFHvXo/uGmUdY1jm4ke8RNOpem73kLbYmFrb314UM+AwwF3QxKc5PRHYIRy4HHFlCRagbl0+pga42w1Obp5PEVPCoyt9HAJ5FRIaR5Y7hogn1HiqpZXlnDRGWBVHqASvyntc2sHtXwIhtihUzAT037+Bk5+BS1tsYbJhvCmj12GUypWvUyryUH0354SvKitoHbfPITH8Tn7dKissftfF4J9o="
-    on:
-      tags: true
+jobs:
+  include:
+    - stage: check
       rvm: 2.1.9
-      condition: "($SKIP_PUBLISH != true)"
+      script:
+        - bundle exec rake pkg:compare_latest_tag
+        - bundle exec rake pkg:create_tag_changelog
+        - bundle exec rake pkg:gem
 
+    # Test with Ruby versions packaged with standard Puppet All-in-one installs
+    - stage: spec
+      rvm: 2.4.1
+      env: SIMP_SKIP_NON_SIMPOS_TESTS=1
+      script:
+        - bundle exec rake spec
 
+    - stage: spec
+      rvm: 2.1.9
+      env: SIMP_SKIP_NON_SIMPOS_TESTS=1
+      script:
+        - bundle exec rake spec
+
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
+      before_deploy:
+        - bundle exec rake clobber
+        - "export GEM_VERSION=`ruby -r ./lib/simp/cli/version.rb -e 'puts Simp::Cli::VERSION'`"
+        - '[[ $TRAVIS_TAG =~ ^${GEM_VERSION}$ ]]'
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "R6KNY9wDFtWVDXA0tC/We+OunS+8wiu4YHymDh5NBO/NWm0Dt5I6+Ado8QfjW5jZWja0Bl1cpjsf65Ln+XMQ6MDsiRvidnqMKTyyzjF/Y5U1inRm6i2+XGCCxKPGVJY6IrSidJg0NIlqKKghaq7DYDT5cDopcA/xHqY/S4mxvJf1OQQ7JdN0GtOrNv2h+lL9qlpvE8ogvb0fQyZXyKkz3TCCyauzb2w6ay4TjIqD2yo8yy3nUInyRDJf6XIyxWdiOFNHe3cwiYblqmosPUMYBf6qkzGPzmsQsmPoqN0+WopMnaNShPoiVoTdXIJDPe0deWmFbvFUvYL1zYoxZ+Vggjd+wXXJBiB3i/7xC3MOj9EPDQtY4AdjG5ZM6mqyjX7jFzv31DfK8WPa11OhDeOYgWfTc8b3MkeDWsKqC/IjPs83M8Qz03Fwxtocx0cNP2BmIDxxMi8GRT45CG3BYONVFHvXo/uGmUdY1jm4ke8RNOpem73kLbYmFrb314UM+AwwF3QxKc5PRHYIRy4HHFlCRagbl0+pga42w1Obp5PEVPCoyt9HAJ5FRIaR5Y7hogn1HiqpZXlnDRGWBVHqASvyntc2sHtXwIhtihUzAT037+Bk5+BS1tsYbJhvCmj12GUypWvUyryUH0354SvKitoHbfPITH8Tn7dKissftfF4J9o="
+          on:
+            tags: true
+            rvm: 2.4.1
+            condition: "($SKIP_PUBLISH != true)"
 

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'facter'
 gem 'highline', :path => 'ext/gems/highline'
 gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>4')
 gem 'rake'
-gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 4.0.0', '<= 6.0.0'])
+gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2.0', '<= 6.0.0'])
 
 group :testing do
   # bootstrap common environment variables

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ require 'rake/clean'
 require 'rspec/core/rake_task'
 require 'rubygems'
 require 'simp/rake'
+require 'simp/cli/version'
 
 Simp::Rake::Pkg.new(File.dirname(__FILE__))
 
@@ -98,6 +99,21 @@ namespace :pkg do
     end
   end
 
+  desc 'ensure simp cli Ruby version matches its RPM spec file version'
+  task :validate_ruby_version do
+    basedir = File.dirname(__FILE__)
+    info, changelogs = Simp::RelChecks::load_and_validate_changelog(basedir, false)
+    spec_file_version = Gem::Version.new(info.version)
+    ruby_version = Gem::Version.new(Simp::Cli::VERSION)
+    if spec_file_version != ruby_version
+      fail("ERROR: Version mismatch: " +
+        " spec file version = #{spec_file_version}," +
+        " version.rb version = #{ruby_version}")
+    end
+  end
+
   Rake::Task[:rpm].prerequisites.unshift(:gem)
+
+  Rake::Task[:compare_latest_tag].enhance [:validate_ruby_version]
 end
 # vim: syntax=ruby

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 4.0.4
+%global cli_version 4.0.5
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up
@@ -100,6 +100,9 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Wed Jan 31 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.5
+- Clarify confusing svckill::mode description provided by simp config
+
 * Mon Oct 16 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.4
 - Fix intermittent failure in RPM builds due to missing rubygems
 

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -102,6 +102,8 @@ EOM
 %changelog
 * Wed Jan 31 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.5
 - Clarify confusing svckill::mode description provided by simp config
+- Use modern OS facts in simp config, instead of legacy facts that
+  require LSB packages to be installed.
 
 * Mon Oct 16 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.0.4
 - Fix intermittent failure in RPM builds due to missing rubygems

--- a/lib/simp/cli/config/items/action/set_grub_password_action.rb
+++ b/lib/simp/cli/config/items/action/set_grub_password_action.rb
@@ -19,9 +19,7 @@ module Simp::Cli::Config
     def apply
       @applied_status = :failed
       grub_hash = get_item('grub::password').value
-      # TODO In the future, this logic may need to be reworked to
-      #      consider OS family in addition to OS version.
-      if Facter.value('lsbmajdistrelease') > "6" then
+      if Facter.value('os')['release']['major'] > "6"
         # TODO: beg team hercules to make a augeas provider for grub2 passwords?
         result = execute("sed -i 's/password_pbkdf2 root.*$/password_pbkdf2 root #{grub_hash}/' /etc/grub.d/01_users")
         result = result && execute("grub2-mkconfig -o /etc/grub2.cfg")

--- a/lib/simp/cli/config/items/data/grub_password.rb
+++ b/lib/simp/cli/config/items/data/grub_password.rb
@@ -33,7 +33,7 @@ stored in #{@key}.}
     def encrypt string
       result   = nil
       password = string
-      if Facter.value('lsbmajdistrelease') > '6'
+      if Facter.value('os')['release']['major'] > "6"
         result = `grub2-mkpasswd-pbkdf2 <<EOM\n#{password}\n#{password}\nEOM`.split.last
       else
         require 'digest/sha2'

--- a/lib/simp/cli/config/items/data/svckill_mode.rb
+++ b/lib/simp/cli/config/items/data/svckill_mode.rb
@@ -17,20 +17,22 @@ module Simp::Cli::Config
 
 NOTICE: svckill is the mechanism that SIMP uses to comply with the
 requirement that no unauthorized services are running on your system.
-Is it HIGHLY recommended that you set this to 'enforcing'. Please be
-aware that, if you do this, svckill will stop ALL services that are
-not referenced in your Puppet configuration.}
+If you are fully aware of all services that need to be running on the
+system, including any custom applications, use 'enforcing'.  If you
+first need to ascertain which services should be running on the system,
+use 'warning'.}
 
       @warning_msgs = {
-        :enforcing => %Q{IMPORTANT:  Be sure to register your site-specific services with svckill
-to prevent them from being automatically shut down and disabled.
+        :enforcing =>
+%Q{IMPORTANT:  Be sure to register your site-specific services with
+svckill to prevent them from being automatically shut down and disabled.
 See svckill::ignore and svckill::ignore_files.},
 
-        :warning => %Q{IMPORTANT: 'warning' will allow you to ascertain the list of undeclared
-services running on your system.  However, to ensure no unnecessary
-services are running, you must register these services with svckill
-and then change #{@key} to 'enforcing'.  See svckill::ignore and
-svckill::ignore_files.}
+        :warning =>
+%Q{IMPORTANT: Once you have examined the list of undeclared services
+reported by svckill and have determined which of those should be
+allowed, register the allowed services with svckill and then change
+#{@key} to 'enforcing'.  See svckill::ignore and svckill::ignore_files.}
       }
     end
 

--- a/lib/simp/cli/config/items/list_item.rb
+++ b/lib/simp/cli/config/items/list_item.rb
@@ -28,7 +28,9 @@ module Simp::Cli::Config
     def instructions
       extra = 'hit enter to skip'
       extra = "hit enter to accept default value" if default_value
-      instructions = "Enter a comma or space-delimited list (#{extra})"
+      # Code actually allows comma and space delimited lists, but
+      # a simpler instruction to the end user is best
+      instructions = "Enter a space-delimited list (#{extra})"
       ::HighLine.color( instructions, ::HighLine.const_get('YELLOW') )
     end
 

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '4.0.4'
+  VERSION = '4.0.5'
 end

--- a/spec/bin/simp_spec.rb
+++ b/spec/bin/simp_spec.rb
@@ -26,7 +26,8 @@ def execute(command, input_file = nil)
       # be in the Ruby load path due to kludgey logic in bin/simp.
       # This causes problems. For example, we will get warnings
       # about already initialized constants in pathname.rb.
-      line.include?('pathname.rb')
+      line.include?('warning: already initialized constant') or
+      line.include?('warning: previous definition of')
     end.join("\n")
   end
   { :exitstatus => exitstatus, :stdout => stdout, :stderr => stderr }

--- a/spec/lib/simp/cli/config/items/data/grub_password_spec.rb
+++ b/spec/lib/simp/cli/config/items/data/grub_password_spec.rb
@@ -11,7 +11,7 @@ describe Simp::Cli::Config::Item::GrubPassword do
     # NOTE: not much we can test except the hashed string length and characteristics of the type of hash
     it "encrypts grub_passwords" do
       crypted_pw = @ci.encrypt( 'foo' )
-      if Facter.value('lsbmajdistrelease') <= '6'
+      if Facter.value('os')['release']['major'] <= '6'
         expect( crypted_pw ).to match /^\$6\$/
         expect( 97..98 ).to cover( crypted_pw.length )
       else


### PR DESCRIPTION
- Reworked description and info messages to be more clear.
- Simplified instructions for entering arrays.
- Attempt (again) to work around warnings about duplicate constants
  that arise because of multiple rubies in the Ruby load path
  on Puppet-managed development systems.  These warning messages
  break 'simp config' tests that are verifying the content of stderr.
- Add pkg:compare_latest_tag check to .travis.yml
- Extend pkg:compare_latest_tag to also check that the simp cli Ruby
  version matches the version in the RPM spec file.
- Use more readily-available TravisCI containers

SIMP-4376 #close 
SIMP-3852 #comment Code changes