### PR TITLE
(SIMP-4386) simp config fails to set GRUB password CentOS6 EFI

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -100,6 +100,10 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Thu Feb 08 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.5
+- Fix bug in which simp config failed to set the GRUB password
+  on a CentOS 6 system booted using EFI
+
 * Wed Jan 31 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.0.5
 - Clarify confusing svckill::mode description provided by simp config
 - Use modern OS facts in simp config, instead of legacy facts that

--- a/spec/lib/simp/cli/commands/config_spec.rb
+++ b/spec/lib/simp/cli/commands/config_spec.rb
@@ -190,7 +190,7 @@ describe Simp::Cli::Commands::Config do
     context 'non-root user' do
 
      it "creates valid yaml files for 'simp' scenario, interactively accepting all defaults" do
-       skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+       skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
        @input.reopen(generate_simp_input_accepting_defaults)
        begin
          Simp::Cli::Commands::Config.run(['-o', @answers_output_file,
@@ -209,7 +209,7 @@ describe Simp::Cli::Commands::Config do
      end
 
      it "creates valid output yaml files for 'simp_lite' scenario, interactively setting values" do
-       skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+       skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
        @input.reopen(generate_simp_lite_input_setting_values)
        begin
          Simp::Cli::Commands::Config.run(['-o', @answers_output_file,
@@ -228,7 +228,7 @@ describe Simp::Cli::Commands::Config do
      end
 
      it "creates valid output yaml files for 'poss' scenario, interactively setting values " do
-       skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+       skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
        @input.reopen(generate_poss_input_setting_values)
        begin
          Simp::Cli::Commands::Config.run(['-o', @answers_output_file,
@@ -247,7 +247,7 @@ describe Simp::Cli::Commands::Config do
      end
 
      it 'creates valid output yaml files for user using minimal prompts' do
-       skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+       skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
 
        input_string = ''
        input_string << "simp_lite\n"          << # 'simp_lite' scenario
@@ -268,7 +268,7 @@ describe Simp::Cli::Commands::Config do
      end
 
      it 'creates valid answers yaml using existing file, command line overrides, and prompts' do
-       skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+       skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
        input_string = "\n" # use suggested interface, as has to be a valid one
        @input.reopen(input_string)
        @input.rewind
@@ -293,7 +293,7 @@ describe Simp::Cli::Commands::Config do
      end
 
      it 'does not apply actions when user is not root' do
-       skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+       skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
        @input.reopen(generate_simp_input_accepting_defaults)
        begin
          Simp::Cli::Commands::Config.run(['-o', @answers_output_file,
@@ -349,7 +349,7 @@ describe Simp::Cli::Commands::Config do
      end
 
      it 'prints a summary of actions' do
-       skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+       skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
        @input.reopen(generate_simp_input_accepting_defaults)
        begin
          Simp::Cli::Commands::Config.run(['-o', @answers_output_file,
@@ -400,7 +400,7 @@ describe Simp::Cli::Commands::Config do
 
     context 'creates detailed log file' do
        it 'logs detailed messages when normal verbosity specified' do
-         skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+         skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
          @input.reopen(generate_simp_input_accepting_defaults)
          begin
            Simp::Cli::Commands::Config.run(['-o', @answers_output_file,
@@ -419,7 +419,7 @@ describe Simp::Cli::Commands::Config do
        end
 
        it 'logs detailed messages when quiet verbosity specified' do
-         skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+         skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
          @input.reopen(generate_simp_input_accepting_defaults)
          begin
            Simp::Cli::Commands::Config.run(['-o', @answers_output_file,
@@ -492,7 +492,7 @@ describe Simp::Cli::Commands::Config do
     end
 
     it 'logs debug output to the console when --verbose option selected' do
-      skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+      skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
       @input.reopen(generate_simp_input_accepting_defaults)
       begin
         Simp::Cli::Commands::Config.run(['-o', @answers_output_file,
@@ -518,7 +518,7 @@ describe Simp::Cli::Commands::Config do
     end
 
     it 'raises an RuntimeError when noninteractive and input yaml is incomplete' do
-      skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+      skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
 
       expect {  Simp::Cli::Commands::Config.run(['-o', @answers_output_file, '--apply',
         File.join(files_dir, 'prev_simp_conf.yaml'), '-l', @log_file]) }.to raise_error(RuntimeError,
@@ -526,7 +526,7 @@ describe Simp::Cli::Commands::Config do
     end
 
     it 'raises an RuntimeError when noninteractive and input answers yaml has an invalid value' do
-      skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+      skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
 
       # Since network::interface value fails validation when read in, that value
       # is skipped. This results in a missing anwer for network::interface.

--- a/spec/lib/simp/cli/config/items/action/configure_network_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/configure_network_action_spec.rb
@@ -32,7 +32,7 @@ describe Simp::Cli::Config::Item::ConfigureNetworkAction do
     end
 
     it 'sets applied_status to :failed when puppet apply fails to configure network' do
-      skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+      skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
       @ci.config_items = init_config_items( {'network::dhcp' => 'static'} )
       @ci.apply
       expect( @ci.applied_status ).to eq :failed

--- a/spec/lib/simp/cli/config/items/action/set_grub_password_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/set_grub_password_action_spec.rb
@@ -10,15 +10,86 @@ describe Simp::Cli::Config::Item::SetGrubPasswordAction do
 
   # TODO: test successes with acceptance tests
   describe '#apply' do
-    pending 'sets grub password for CentOS 6.x'
-    pending 'sets grub password for CentOS 7.x'
-    it 'sets applied_status to :failed when fails to set grub password ' do
-      skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+    let(:grub_password) {
       grub_password = Simp::Cli::Config::Item::GrubPassword.new
-      grub_password.value =  'vsB2myX+l8-p-FOmbjG%%Exr0R3z8Mkm'
-      @ci.config_items = { grub_password.key => grub_password }
-      @ci.apply
-      expect( @ci.applied_status ).to eq :failed
+      grub_password.value = 'vsB2myX+l8-p-FOmbjG%%Exr0R3z8Mkm'
+      grub_password
+    }
+
+    context 'CentOS 6.x' do
+      let(:os_fact)  { { 'release' => { 'major' => '6'} } }
+
+      it 'sets grub password for BIOS boot and sets applied_status to :success' do
+        allow(Facter).to receive(:value).with('os').and_return(os_fact)
+        allow(File).to receive(:exist?).with('/boot/grub/grub.conf').and_return(true)
+        allow(@ci).to receive(:execute).and_return(true)
+
+        @ci.config_items = { grub_password.key => grub_password }
+        @ci.apply
+        expect( @ci.applied_status ).to eq :succeeded
+      end
+
+      it 'sets grub password for EFI boot and sets applied_status to :success' do
+        allow(Facter).to receive(:value).with('os').and_return(os_fact)
+        allow(File).to receive(:exist?).with('/boot/grub/grub.conf').and_return(false)
+        allow(File).to receive(:exist?).with('/boot/efi/EFI/redhat/grub.conf').and_return(true)
+        allow(@ci).to receive(:execute).and_return(true)
+
+        @ci.config_items = { grub_password.key => grub_password }
+        @ci.apply
+        expect( @ci.applied_status ).to eq :succeeded
+      end
+
+      it 'fails when boot file not found' do
+        allow(Facter).to receive(:value).with('os').and_return(os_fact)
+        allow(File).to receive(:exist?).with('/boot/grub/grub.conf').and_return(false)
+        allow(File).to receive(:exist?).with('/boot/efi/EFI/redhat/grub.conf').and_return(false)
+
+        @ci.config_items = { grub_password.key => grub_password }
+        expect{ @ci.apply }.to  raise_error(/Could not find grub.conf/)
+      end
+
+      it "sets applied_status to :failed when 'sed' command fails" do
+        allow(Facter).to receive(:value).with('os').and_return(os_fact)
+        allow(File).to receive(:exist?).with('/boot/grub/grub.conf').and_return(false)
+        allow(File).to receive(:exist?).with('/boot/efi/EFI/redhat/grub.conf').and_return(true)
+        allow(@ci).to receive(:execute).and_return(false)
+
+        @ci.config_items = { grub_password.key => grub_password }
+        @ci.apply
+        expect( @ci.applied_status ).to eq :failed
+      end
+    end
+
+    context 'CentOS 7.x' do
+      let(:os_fact)  { { 'release' => { 'major' => '7'} } }
+
+      it 'sets grub password and sets applied_status to :success' do
+        allow(Facter).to receive(:value).with('os').and_return(os_fact)
+        allow(@ci).to receive(:execute).and_return(true, true)
+
+        @ci.config_items = { grub_password.key => grub_password }
+        @ci.apply
+        expect( @ci.applied_status ).to eq :succeeded
+      end
+
+      it "sets applied_status to :failed when 'sed' command fails" do
+        allow(Facter).to receive(:value).with('os').and_return(os_fact)
+        allow(@ci).to receive(:execute).and_return(false)
+
+        @ci.config_items = { grub_password.key => grub_password }
+        @ci.apply
+        expect( @ci.applied_status ).to eq :failed
+      end
+
+      it "sets applied_status to :failed when 'grub2-mkconf' command fails" do
+        allow(Facter).to receive(:value).with('os').and_return(os_fact)
+        allow(@ci).to receive(:execute).and_return(true, false)
+
+        @ci.config_items = { grub_password.key => grub_password }
+        @ci.apply
+        expect( @ci.applied_status ).to eq :failed
+      end
     end
   end
 

--- a/spec/lib/simp/cli/config/items/action/set_hostname_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/set_hostname_action_spec.rb
@@ -15,7 +15,7 @@ describe Simp::Cli::Config::Item::SetHostnameAction do
     end
 
     it 'sets applied_status to :failed when fails to set hostname' do
-      skip("Test can't be run as root") if ENV.fetch('USER') == 'root'
+      skip("Test can't be run as root") if ENV['USER'] == 'root' or ENV['HOME'] == '/root'
       cli_network_hostname = Simp::Cli::Config::Item::CliNetworkHostname.new
       cli_network_hostname.value = 'oops.test.local'
       @ci.config_items = { cli_network_hostname.key => cli_network_hostname }


### PR DESCRIPTION
- Fixed code that sets GRUB password for CentOS6
- Tweaked test skip logic for gitlab. 

SIMP-4386 #close