### PR TITLE
(SIMP-4576)  Update set grub password 

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -21,6 +21,7 @@ Source1: %{gemname}-%{cli_version}.gem
 Requires: puppet >= 3
 Requires: facter >= 2.2
 Requires: rubygem(%{gemname}-highline) >= %{highline_version}
+Requires: pupmod-herculesteam-augeasproviders_grub >= 3.0.1
 BuildRequires: ruby(rubygems)
 BuildRequires: ruby
 BuildArch: noarch
@@ -102,6 +103,7 @@ EOM
 %changelog
 * Mon Apr 23 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.1.0
 - removed simp_options::selinux references in tests.
+- update setting of grub2 password to use augeausproviders_grub.
 
 * Wed Apr 11 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 4.1.0
 - 'simp config' bug fixes

--- a/lib/simp/cli/config/items/action/set_grub_password_action.rb
+++ b/lib/simp/cli/config/items/action/set_grub_password_action.rb
@@ -39,7 +39,7 @@ module Simp::Cli::Config
     # This requires augeasproviders_grub 3.0.1 or later.  There were errors in the
     # provider before this time that did not create the file in /etc/grub.d corectly.
     def set_password_grub(grub_hash)
-      cmd = %Q(#{@puppet_apply_cmd} -e "grub_user { 'root': password => '#{grub_hash}'; superuser => true }")
+      cmd = %Q(#{@puppet_apply_cmd} -e "grub_user { 'root': password => '#{grub_hash}', superuser => true }")
       result = execute(cmd)
     end
 

--- a/lib/simp/cli/config/items/action/set_grub_password_action.rb
+++ b/lib/simp/cli/config/items/action/set_grub_password_action.rb
@@ -36,9 +36,11 @@ module Simp::Cli::Config
       "Setting of GRUB password #{@applied_status}"
     end
 
+    # This requires augeasproviders_grub 3.0.1 or later.  There were errors in the
+    # provider before this time that did not create the file in /etc/grub.d corectly.
     def set_password_grub(grub_hash)
-      result = execute("sed -i 's/password_pbkdf2 root.*$/password_pbkdf2 root #{grub_hash}/' /etc/grub.d/01_users")
-      result && execute("grub2-mkconfig -o /etc/grub2.cfg")
+      cmd = %Q(#{@puppet_apply_cmd} -e "grub_user { 'root': password => '#{grub_hash}'; superuser => true }")
+      result = execute(cmd)
     end
 
     def set_password_old_grub(grub_hash)

--- a/spec/lib/simp/cli/config/items/action/set_grub_password_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/set_grub_password_action_spec.rb
@@ -66,7 +66,7 @@ describe Simp::Cli::Config::Item::SetGrubPasswordAction do
 
       it 'calls puppet apply and sets applied_status to :success' do
         allow(Facter).to receive(:value).with('os').and_return(os_fact)
-        allow(@ci).to receive(:execute).with(%Q(puppet apply  -e "grub_user { 'root': password => '#{grub_password.value}'; superuser => true }")).and_return(true)
+        allow(@ci).to receive(:execute).with(%Q(puppet apply  -e "grub_user { 'root': password => '#{grub_password.value}', superuser => true }")).and_return(true)
 
         @ci.config_items = { grub_password.key => grub_password }
         @ci.apply

--- a/spec/lib/simp/cli/config/items/action/set_grub_password_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/set_grub_password_action_spec.rb
@@ -64,27 +64,18 @@ describe Simp::Cli::Config::Item::SetGrubPasswordAction do
     context 'CentOS 7.x' do
       let(:os_fact)  { { 'release' => { 'major' => '7'} } }
 
-      it 'sets grub password and sets applied_status to :success' do
+      it 'calls puppet apply and sets applied_status to :success' do
         allow(Facter).to receive(:value).with('os').and_return(os_fact)
-        allow(@ci).to receive(:execute).and_return(true, true)
+        allow(@ci).to receive(:execute).with(%Q(puppet apply  -e "grub_user { 'root': password => '#{grub_password.value}'; superuser => true }")).and_return(true)
 
         @ci.config_items = { grub_password.key => grub_password }
         @ci.apply
         expect( @ci.applied_status ).to eq :succeeded
       end
 
-      it "sets applied_status to :failed when 'sed' command fails" do
+      it "sets applied_status to :failed when  puppet apply fails" do
         allow(Facter).to receive(:value).with('os').and_return(os_fact)
         allow(@ci).to receive(:execute).and_return(false)
-
-        @ci.config_items = { grub_password.key => grub_password }
-        @ci.apply
-        expect( @ci.applied_status ).to eq :failed
-      end
-
-      it "sets applied_status to :failed when 'grub2-mkconf' command fails" do
-        allow(Facter).to receive(:value).with('os').and_return(os_fact)
-        allow(@ci).to receive(:execute).and_return(true, false)
 
         @ci.config_items = { grub_password.key => grub_password }
         @ci.apply


### PR DESCRIPTION
  - modify the set of the grub2 password to use augeasproviders
    to set password in /etc/grub.d.  This will mean you don't need
    to figureout where the grub.cfg file is.

SIMP-4576 #close
SIMP-4832 #close
SIMP-4833 #close