### PR TITLE
(SIMP-MAINT) Fix spec tests in TravisCI

### DIFF
--- a/ext/gems/highline/highline.gemspec
+++ b/ext/gems/highline/highline.gemspec
@@ -13,7 +13,8 @@ SPEC = Gem::Specification.new do |spec|
   spec.files    = `git ls-files`.split("\n")
 
   spec.test_files       =  `git ls-files -- test/*.rb`.split("\n")
-  spec.has_rdoc         =  true
+# deprecated feature with no replacement
+#  spec.has_rdoc         =  true
   spec.extra_rdoc_files =  %w[README.rdoc INSTALL TODO Changelog.md LICENSE]
   spec.rdoc_options     << '--title' << 'HighLine Documentation' <<
                            '--main'  << 'README'


### PR DESCRIPTION
Comment out deprecated gemspec feature that spews warnings to stderr,
which in turn, causes simp-cli spec tests to fail.