### PR TITLE
(SIMP-5063) Use puppet config value in bootstrap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,5 +50,5 @@ group :development do
   # Generate HISTORY.md from git tags (experimental, but promising)
   gem 'gitlog-md'
 
-  gem 'rubocop'
+  gem 'rubocop', '>= 0.49'
 end

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -390,8 +390,8 @@ EOM
 
     begin
       info("Waiting for puppetserver to accept connections on port #{port}", 'cyan')
-      curl_cmd = "curl -sS --cert #{Simp::Cli::Utils.puppet_info[:config]['certdir']}/`hostname`.pem" +
-        " --key #{Simp::Cli::Utils.puppet_info[:config]['ssldir']}/private_keys/`hostname`.pem -k -H" +
+      curl_cmd = "curl -sS --cert #{Simp::Cli::Utils.puppet_info[:config]['hostcert']}" +
+        " --key #{Simp::Cli::Utils.puppet_info[:config]['hostprivkey']}` -k -H" +
         " \"Accept: s\" https://localhost:#{port}/production/certificate_revocation_list/ca"
       debug(curl_cmd)
       running = (%x{#{curl_cmd} 2>&1} =~ /CRL/)

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '4.1.0'
+  VERSION = '4.1.1'
 end


### PR DESCRIPTION
The 'hostname' command was used during bootstrap to access the puppet
certificates. Unfortunately, this can cause issues depending on how the
hostname has been set up.

Switched this to use the puppet certificate and key directly.

SIMP-5063 #close