### PR TITLE
(SIMP-5476) 'simp config' fails for non-ISO RPM install

### DIFF
--- a/spec/lib/simp/cli/utils_spec.rb
+++ b/spec/lib/simp/cli/utils_spec.rb
@@ -58,8 +58,28 @@ describe Simp::Cli::Utils do
       expect( Simp::Cli::Utils::get_stock_simp_env_datadir ).to be_nil
     end
 
-    it 'returns nil when neither an env-specific hieradata file or the expected Hiera 3 data dir exists' do
-      expect( Simp::Cli::Utils::get_stock_simp_env_datadir ).to be_nil
+    it 'returns Hiera 3 environment data dir when allow_pre_env_copy_eval=true and /usr/share/simp/environments/simp has a hieradata dir' do
+      allow(Dir).to receive(:exist?).with(@simp_env_dir).and_return(false)
+      allow(Dir).to receive(:exist?).with('/usr/share/simp/environments/simp/data').and_return(false)
+      allow(Dir).to receive(:exist?).with('/usr/share/simp/environments/simp/hieradata').and_return(true)
+      expect( Simp::Cli::Utils::get_stock_simp_env_datadir(true) ).to eq File.join(@simp_env_dir, 'hieradata')
+    end
+
+    it 'returns Hiera 5 environment data dir when allow_pre_env_copy_eval=true and /usr/share/simp/environments/simp has a data dir' do
+      allow(Dir).to receive(:exist?).with(@simp_env_dir).and_return(false)
+      allow(Dir).to receive(:exist?).with('/usr/share/simp/environments/simp/data').and_return(true)
+      expect( Simp::Cli::Utils::get_stock_simp_env_datadir(true) ).to eq File.join(@simp_env_dir, 'data')
+    end
+
+    it 'returns nil when allow_pre_env_copy_eval=true and no hieradata files or RPM-installed simp env data directories exist' do
+      allow(Dir).to receive(:exist?).with(@simp_env_dir).and_return(false)
+      allow(Dir).to receive(:exist?).with('/usr/share/simp/environments/simp/data').and_return(false)
+      allow(Dir).to receive(:exist?).with('/usr/share/simp/environments/simp/hieradata').and_return(false)
+      expect( Simp::Cli::Utils::get_stock_simp_env_datadir(true) ).to be_nil
+    end
+
+    it 'returns nil when allow_pre_env_copy_eval=false and no hireadata files exist' do
+      expect( Simp::Cli::Utils::get_stock_simp_env_datadir(false) ).to be_nil
     end
   end
 


### PR DESCRIPTION
Add logic to allow 'simp config' to determine the 'simp'
environment data directory before it exists in a non-ISO
SIMP RPM install.

This small code change requires a big explanation.
For a SIMP non-ISO RPM install, the 'simp' environment
skeleton and SIMP modules are only installed in
/usr/share/simp.  They are not automatically copied over
to the the puppet environments directory.  'simp config'
detects the missing 'simp' environment, and, using the
simp-adapter, executes that copy.

Unfortunately, as currently written, 'simp config' needs
to know the 'simp' environment data directory *before* it
executes the environment copy.  This is because 'simp config'
uses the 'simp' environment data directory to configure other
'simp config' actions at the time it generates its internal
decision tree structure. The environment copy does not
happen during that decision tree generation, but afterwards,
when 'simp config' traverses the decision tree.

The easiest fix that doesn't require significant 'simp config'
rework, is to *ASSUME* the 'simp' environment copy will take
place for this specific scenario, and thus assume the 'simp'
environment data directory will match the data directory within
/usr/share/simp/environments/simp.  If for any reason the copy
does not take place, 'simp config' will fail when it tries to
create/modify YAML files in the expected data directory.

SIMP-5476 #close