### PR TITLE
(SIMP-5932) Add puppetserver wait option to bootstrap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ addons:
 
 before_install:
   - rm -f Gemfile.lock
+  - gem install -v '~> 1.16' bundler
 
 
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ language: ruby
 cache: bundler
 sudo: false
 
+stages:
+  - check
+  - spec
+  - name: deploy
+    if: 'tag IS present'
+
 bundler_args: --without development system_tests --path .vendor
 
 notifications:
@@ -21,9 +27,13 @@ before_install:
 
 
 jobs:
+  allow_failures:
+    - name: 'Ruby packaged with Puppet 6.x (allowed to fail)'
+
   include:
     - stage: check
-      rvm: 2.1.9
+      name: 'Syntax, style, and validation checks'
+      rvm: 2.4.4
       script:
         - bundle exec rake pkg:compare_latest_tag
         - bundle exec rake pkg:create_tag_changelog
@@ -31,6 +41,17 @@ jobs:
 
     # Test with Ruby versions packaged with standard Puppet All-in-one installs
     - stage: spec
+      name: 'Ruby packaged with Puppet 4.x'
+      rvm: 2.1.9
+      env:
+        - PUPPET_VERSION="~> 4.10"
+        - SIMP_SKIP_NON_SIMPOS_TESTS=1
+        - SIMP_CLI_GEMSPEC_NO_PUPPET_VERSION=yes
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      name: 'Ruby packaged with Puppet 5.x'
       rvm: 2.4.4
       env:
         - PUPPET_VERSION="~> 5.5"
@@ -40,9 +61,10 @@ jobs:
         - bundle exec rake spec
 
     - stage: spec
-      rvm: 2.1.9
+      name: 'Ruby packaged with Puppet 6.x (allowed to fail)'
+      rvm: 2.5.1
       env:
-        - PUPPET_VERSION="~> 4.10"
+        - PUPPET_VERSION="~> 6.0"
         - SIMP_SKIP_NON_SIMPOS_TESTS=1
         - SIMP_CLI_GEMSPEC_NO_PUPPET_VERSION=yes
       script:
@@ -62,6 +84,5 @@ jobs:
             secure: "R6KNY9wDFtWVDXA0tC/We+OunS+8wiu4YHymDh5NBO/NWm0Dt5I6+Ado8QfjW5jZWja0Bl1cpjsf65Ln+XMQ6MDsiRvidnqMKTyyzjF/Y5U1inRm6i2+XGCCxKPGVJY6IrSidJg0NIlqKKghaq7DYDT5cDopcA/xHqY/S4mxvJf1OQQ7JdN0GtOrNv2h+lL9qlpvE8ogvb0fQyZXyKkz3TCCyauzb2w6ay4TjIqD2yo8yy3nUInyRDJf6XIyxWdiOFNHe3cwiYblqmosPUMYBf6qkzGPzmsQsmPoqN0+WopMnaNShPoiVoTdXIJDPe0deWmFbvFUvYL1zYoxZ+Vggjd+wXXJBiB3i/7xC3MOj9EPDQtY4AdjG5ZM6mqyjX7jFzv31DfK8WPa11OhDeOYgWfTc8b3MkeDWsKqC/IjPs83M8Qz03Fwxtocx0cNP2BmIDxxMi8GRT45CG3BYONVFHvXo/uGmUdY1jm4ke8RNOpem73kLbYmFrb314UM+AwwF3QxKc5PRHYIRy4HHFlCRagbl0+pga42w1Obp5PEVPCoyt9HAJ5FRIaR5Y7hogn1HiqpZXlnDRGWBVHqASvyntc2sHtXwIhtihUzAT037+Bk5+BS1tsYbJhvCmj12GUypWvUyryUH0354SvKitoHbfPITH8Tn7dKissftfF4J9o="
           on:
             tags: true
-            rvm: 2.4.4
             condition: "($SKIP_PUBLISH != true)"
 

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 4.3.2
+%global cli_version 4.4.0
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up
@@ -126,6 +126,10 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Tue Jan 15 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.0
+- Added a `simp bootstrap` option to set the wait time for the
+  puppetserver to start during the bootstrap process.
+
 * Tue Jan 01 2019 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 4.3.2
 - Fixed error in Changelog
 

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '4.3.2'
+  VERSION = '4.4.0'
 end

--- a/spec/lib/simp/cli/commands/bootstrap_spec.rb
+++ b/spec/lib/simp/cli/commands/bootstrap_spec.rb
@@ -1,0 +1,77 @@
+require 'simp/cli/commands/bootstrap'
+
+describe 'Simp::Cli::Command::Bootstrap#run' do
+  let(:files_dir) { File.join(File.dirname(__FILE__), 'files') }
+
+  before(:each) do
+    @tmp_dir  = Dir.mktmpdir( File.basename(__FILE__) )
+    test_env_dir = File.join(@tmp_dir, 'environments')
+    simp_env_dir = File.join(test_env_dir, 'simp')
+    FileUtils.mkdir(test_env_dir)
+    FileUtils.cp_r(File.join(files_dir, 'environments', 'simp'), test_env_dir)
+
+    allow(Simp::Cli::Utils).to receive(:puppet_info).and_return( {
+      :config => {
+        'agent_disabled_lockfile' => File.join(@tmp_dir, 'agent_disable_lockfile'),
+        'codedir'                 => @tmp_dir,
+        'confdir'                 => @tmp_dir,
+        'hostcert'                => File.join(@tmp_dir, 'test_host.pem'),
+        'hostprivkey'             => File.join(@tmp_dir, 'test_host.key'),
+        'rundir'                  => File.join(@tmp_dir, 'rundir'),
+        'ssldir'                  => File.join(@tmp_dir, 'ssldir'),
+        'vardir'                  => File.join(@tmp_dir, 'vardir')
+      },
+      :environment_path      => test_env_dir,
+      :simp_environment_path => simp_env_dir,
+      :fake_ca_path          => File.join(test_env_dir, 'simp', 'FakeCA'),
+      :is_pe                 => false
+    } )
+
+    @bootstrap = Simp::Cli::Commands::Bootstrap.new
+  end
+
+  after :each do
+    FileUtils.remove_entry_secure @tmp_dir, true
+    Facter.reset  # make sure this test's facts don't affect other tests
+  end
+
+  context 'help' do
+    it 'prints help message' do
+      options_help = <<-EOM
+OPTIONS:
+    -k, --kill_agent                 Ignore agent_catalog_run_lockfile
+                                     status and force kill active puppet
+                                     agents at the beginning of bootstrap.
+    -r, --[no-]remove_ssldir         Remove the existing puppet ssldir.
+                                     If unspecified, user will be prompted
+                                     for action to take.
+    -t, --[no-]track                 Enables/disables the tracker.
+                                     Default is enabled.
+    -u, --unsafe                     Run bootstrap in 'unsafe' mode.
+                                     Interrupts are NOT captured and ignored,
+                                     which may result in a corrupt system.
+                                     Useful for debugging.
+                                     Default is SAFE.
+    -w MIN,                          Number of minutes to wait for the
+        --puppetserver-wait-minutes  puppetserver to start.
+                                     Default is 5 minutes.
+    -v, --[no-]verbose               Enables/disables verbose mode. Prints out
+                                     verbose information.
+    -h, --help                       Print out this message.
+      EOM
+      expected_regex = Regexp.new(Regexp.escape(options_help.strip))
+      expect{ @bootstrap.run(['-h']) }.to output(expected_regex).to_stdout
+    end
+  end
+
+  context 'invalid options' do
+    it 'fails unless --puppetserver-wait-minutes argument is > 0' do
+      expect{ @bootstrap.run(['--puppetserver-wait-minutes', '0']) }.to raise_error(/Invalid puppetserver wait minutes/)
+      expect{ @bootstrap.run(['-w', '-1']) }.to raise_error(/Invalid puppetserver wait minutes/)
+    end
+
+    it 'fails unless --puppetserver-wait-minutes argument parses to a number' do
+      expect{ @bootstrap.run(['--puppetserver-wait-minutes', 'oops']) }.to raise_error(OptionParser::InvalidArgument)
+    end
+  end
+end


### PR DESCRIPTION
- Added a `simp bootstrap` option to set the wait time for
  the puppetserver to start during the bootstrap process.
- Adjusted the help message so it will fit within an
  80-character console window.

SIMP-5932 #close