### PR TITLE
(SIMP-MAINT) Fix info() call

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 4.4.0
+%global cli_version 4.4.1
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -126,6 +126,10 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Thu Feb 07 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.4.1
+- Fixed a typo in an info block that would cause 'simp bootstrap' to fail if it
+  had already been successfully run.
+
 * Tue Jan 15 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 4.4.0
 - Added a `simp bootstrap` option to set the wait time for the
   puppetserver to start during the bootstrap process.

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -391,7 +391,7 @@ EOM
       execute("pkill -9 -f 'puppet agent' >& /dev/null")
       execute('puppet resource service puppet ensure=stopped >& /dev/null')
       FileUtils.rm_f(agent_run_lockfile)
-      info('Successfully removed agent lock file #{agent_run_lockfile}', 'green')
+      info("Successfully removed agent lock file #{agent_run_lockfile}", 'green')
     else
       run_locked = File.exists?(agent_run_lockfile)
       # TODO: make the following spinner a function; it's used in ensure_puppetserver_running as well.

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '4.4.0'
+  VERSION = '4.4.1'
 end


### PR DESCRIPTION
The subsequent processing for `info()` strings would try to interpolate
variables if set which caused an out of scope variable call if simp
bootstrap is run after already having successfully run.