### PR TITLE
(SIMP-MAINT) Ruby modernizations

### DIFF
--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH << File.expand_path( '..', File.dirname(__FILE__) )
+$LOAD_PATH << File.expand_path( '..', __dir__ )
 
 require 'optparse'
 require 'highline'

--- a/lib/simp/cli/commands.rb
+++ b/lib/simp/cli/commands.rb
@@ -1,2 +1,2 @@
-rb_files = File.expand_path( 'commands/**/*.rb', File.dirname(__FILE__))
+rb_files = File.expand_path( 'commands/**/*.rb', __dir__)
 Dir.glob( rb_files ).sort_by(&:to_s).each { |file| require file }

--- a/lib/simp/cli/config/item_list_factory.rb
+++ b/lib/simp/cli/config/item_list_factory.rb
@@ -1,6 +1,6 @@
 require_relative 'errors'
 require_relative 'items'
-require File.expand_path( 'logging', File.expand_path('..',__dir__) )
+require_relative '../logging'
 require_relative 'items_yaml_generator'
 
 module Simp; end

--- a/lib/simp/cli/config/item_list_factory.rb
+++ b/lib/simp/cli/config/item_list_factory.rb
@@ -1,7 +1,7 @@
-require File.expand_path( 'errors', __dir__ )
-require File.expand_path( 'items', __dir__ )
+require_relative 'errors'
+require_relative 'items'
 require File.expand_path( 'logging', File.expand_path('..',__dir__) )
-require File.expand_path( 'items_yaml_generator', __dir__ )
+require_relative 'items_yaml_generator'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items.rb
+++ b/lib/simp/cli/config/items.rb
@@ -1,2 +1,2 @@
-rb_files = File.expand_path( 'items/**/*.rb', File.dirname(__FILE__))
+rb_files = File.expand_path( 'items/**/*.rb', __dir__)
 Dir.glob( rb_files ).sort_by(&:to_s).each { |file| require file }

--- a/lib/simp/cli/config/items/action/add_puppet_hosts_entry_action.rb
+++ b/lib/simp/cli/config/items/action/add_puppet_hosts_entry_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/add_puppet_hosts_entry_action.rb
+++ b/lib/simp/cli/config/items/action/add_puppet_hosts_entry_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/add_yum_server_class_to_server_action.rb
+++ b/lib/simp/cli/config/items/action/add_yum_server_class_to_server_action.rb
@@ -1,4 +1,4 @@
-require 'simp/cli/config/items/add_server_class_action_item'
+require_relative '../add_server_class_action_item'
 
 module Simp::Cli::Config
   class Item::AddYumServerClassToServerAction < AddServerClassActionItem

--- a/lib/simp/cli/config/items/action/answers_yaml_file_writer.rb
+++ b/lib/simp/cli/config/items/action/answers_yaml_file_writer.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/answers_yaml_file_writer.rb
+++ b/lib/simp/cli/config/items/action/answers_yaml_file_writer.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/check_server_yum_config_action.rb
+++ b/lib/simp/cli/config/items/action/check_server_yum_config_action.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../../../defaults', File.dirname(__FILE__) )
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../../../defaults', __dir__ )
+require File.expand_path( '../action_item', __dir__ )
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/check_server_yum_config_action.rb
+++ b/lib/simp/cli/config/items/action/check_server_yum_config_action.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../../../defaults', __dir__ )
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../../../defaults'
+require_relative '../action_item'
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/configure_network_action.rb
+++ b/lib/simp/cli/config/items/action/configure_network_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/configure_network_action.rb
+++ b/lib/simp/cli/config/items/action/configure_network_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/copy_simp_to_environments_action.rb
+++ b/lib/simp/cli/config/items/action/copy_simp_to_environments_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 require 'simp/cli/utils'
 require 'fileutils'
 

--- a/lib/simp/cli/config/items/action/copy_simp_to_environments_action.rb
+++ b/lib/simp/cli/config/items/action/copy_simp_to_environments_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 require 'simp/cli/utils'
 require 'fileutils'
 

--- a/lib/simp/cli/config/items/action/disable_server_local_os_and_simp_yum_repos_action.rb
+++ b/lib/simp/cli/config/items/action/disable_server_local_os_and_simp_yum_repos_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../set_server_hieradata_action_item', File.dirname(__FILE__) )
+require File.expand_path( '../set_server_hieradata_action_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/disable_server_local_os_and_simp_yum_repos_action.rb
+++ b/lib/simp/cli/config/items/action/disable_server_local_os_and_simp_yum_repos_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../set_server_hieradata_action_item', __dir__ )
+require_relative '../set_server_hieradata_action_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/disallow_simp_user_action.rb
+++ b/lib/simp/cli/config/items/action/disallow_simp_user_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../set_server_hieradata_action_item', File.dirname(__FILE__) )
+require File.expand_path( '../set_server_hieradata_action_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/disallow_simp_user_action.rb
+++ b/lib/simp/cli/config/items/action/disallow_simp_user_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../set_server_hieradata_action_item', __dir__ )
+require_relative '../set_server_hieradata_action_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/generate_certificates_action.rb
+++ b/lib/simp/cli/config/items/action/generate_certificates_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item',  File.dirname(__FILE__) )
+require File.expand_path( '../action_item',  __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/generate_certificates_action.rb
+++ b/lib/simp/cli/config/items/action/generate_certificates_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item',  __dir__ )
+require_relative('../action_item')
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_grub_password_action.rb
+++ b/lib/simp/cli/config/items/action/set_grub_password_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_grub_password_action.rb
+++ b/lib/simp/cli/config/items/action/set_grub_password_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_hostname_action.rb
+++ b/lib/simp/cli/config/items/action/set_hostname_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_hostname_action.rb
+++ b/lib/simp/cli/config/items/action/set_hostname_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_production_to_simp_action.rb
+++ b/lib/simp/cli/config/items/action/set_production_to_simp_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 require 'simp/cli/utils'
 require 'fileutils'
 

--- a/lib/simp/cli/config/items/action/set_production_to_simp_action.rb
+++ b/lib/simp/cli/config/items/action/set_production_to_simp_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 require 'simp/cli/utils'
 require 'fileutils'
 

--- a/lib/simp/cli/config/items/action/set_puppet_digest_algorithm_action.rb
+++ b/lib/simp/cli/config/items/action/set_puppet_digest_algorithm_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_puppet_digest_algorithm_action.rb
+++ b/lib/simp/cli/config/items/action/set_puppet_digest_algorithm_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_server_ldap_server_config_action.rb
+++ b/lib/simp/cli/config/items/action/set_server_ldap_server_config_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../set_server_hieradata_action_item', File.dirname(__FILE__) )
+require File.expand_path( '../set_server_hieradata_action_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_server_ldap_server_config_action.rb
+++ b/lib/simp/cli/config/items/action/set_server_ldap_server_config_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../set_server_hieradata_action_item', __dir__ )
+require_relative '../set_server_hieradata_action_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_server_puppetdb_master_config_action.rb
+++ b/lib/simp/cli/config/items/action/set_server_puppetdb_master_config_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../set_server_hieradata_action_item', File.dirname(__FILE__) )
+require File.expand_path( '../set_server_hieradata_action_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_server_puppetdb_master_config_action.rb
+++ b/lib/simp/cli/config/items/action/set_server_puppetdb_master_config_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../set_server_hieradata_action_item', __dir__ )
+require_relative '../set_server_hieradata_action_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_site_scenario_action.rb
+++ b/lib/simp/cli/config/items/action/set_site_scenario_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 require 'fileutils'
 require 'simp/cli/utils'
 

--- a/lib/simp/cli/config/items/action/set_site_scenario_action.rb
+++ b/lib/simp/cli/config/items/action/set_site_scenario_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 require 'fileutils'
 require 'simp/cli/utils'
 

--- a/lib/simp/cli/config/items/action/set_up_puppet_autosign_action.rb
+++ b/lib/simp/cli/config/items/action/set_up_puppet_autosign_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/set_up_puppet_autosign_action.rb
+++ b/lib/simp/cli/config/items/action/set_up_puppet_autosign_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/action/update_puppet_conf_action.rb
+++ b/lib/simp/cli/config/items/action/update_puppet_conf_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 require 'simp/cli/utils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/update_puppet_conf_action.rb
+++ b/lib/simp/cli/config/items/action/update_puppet_conf_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 require 'simp/cli/utils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/warn_client_yum_config_action.rb
+++ b/lib/simp/cli/config/items/action/warn_client_yum_config_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../action_item'
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/warn_client_yum_config_action.rb
+++ b/lib/simp/cli/config/items/action/warn_client_yum_config_action.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../action_item', __dir__ )
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/warn_lockout_risk_action.rb
+++ b/lib/simp/cli/config/items/action/warn_lockout_risk_action.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../../../defaults', File.dirname(__FILE__) )
-require File.expand_path( '../action_item', File.dirname(__FILE__) )
+require File.expand_path( '../../../defaults', __dir__ )
+require File.expand_path( '../action_item', __dir__ )
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action/warn_lockout_risk_action.rb
+++ b/lib/simp/cli/config/items/action/warn_lockout_risk_action.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../../../defaults', __dir__ )
-require File.expand_path( '../action_item', __dir__ )
+require_relative '../../../defaults'
+require_relative '../action_item'
 require 'fileutils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/action_item.rb
+++ b/lib/simp/cli/config/items/action_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', File.dirname(__FILE__) )
+require File.expand_path( 'item', __dir__ )
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items/action_item.rb
+++ b/lib/simp/cli/config/items/action_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', __dir__ )
+require_relative 'item'
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items/class_item.rb
+++ b/lib/simp/cli/config/items/class_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', File.dirname(__FILE__) )
+require File.expand_path( 'item', __dir__ )
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items/class_item.rb
+++ b/lib/simp/cli/config/items/class_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', __dir__ )
+require_relative 'item'
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items/data/cli_has_simp_filesystem_yum_repo.rb
+++ b/lib/simp/cli/config/items/data/cli_has_simp_filesystem_yum_repo.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_has_simp_filesystem_yum_repo.rb
+++ b/lib/simp/cli/config/items/data/cli_has_simp_filesystem_yum_repo.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_has_simp_local_user.rb
+++ b/lib/simp/cli/config/items/data/cli_has_simp_local_user.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 require 'etc'
 
 module Simp; end

--- a/lib/simp/cli/config/items/data/cli_has_simp_local_user.rb
+++ b/lib/simp/cli/config/items/data/cli_has_simp_local_user.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 require 'etc'
 
 module Simp; end

--- a/lib/simp/cli/config/items/data/cli_is_ldap_server.rb
+++ b/lib/simp/cli/config/items/data/cli_is_ldap_server.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_is_ldap_server.rb
+++ b/lib/simp/cli/config/items/data/cli_is_ldap_server.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_is_simp_environment_installed.rb
+++ b/lib/simp/cli/config/items/data/cli_is_simp_environment_installed.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_is_simp_environment_installed.rb
+++ b/lib/simp/cli/config/items/data/cli_is_simp_environment_installed.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_log_servers_specified.rb
+++ b/lib/simp/cli/config/items/data/cli_log_servers_specified.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_log_servers_specified.rb
+++ b/lib/simp/cli/config/items/data/cli_log_servers_specified.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_dhcp.rb
+++ b/lib/simp/cli/config/items/data/cli_network_dhcp.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_dhcp.rb
+++ b/lib/simp/cli/config/items/data/cli_network_dhcp.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_gateway.rb
+++ b/lib/simp/cli/config/items/data/cli_network_gateway.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_gateway.rb
+++ b/lib/simp/cli/config/items/data/cli_network_gateway.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_hostname.rb
+++ b/lib/simp/cli/config/items/data/cli_network_hostname.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
-require File.expand_path( '../../utils', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
+require File.expand_path( '../../utils', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_hostname.rb
+++ b/lib/simp/cli/config/items/data/cli_network_hostname.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../item', __dir__ )
-require File.expand_path( '../../utils', __dir__ )
+require_relative '../item'
+require_relative '../../utils'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_interface.rb
+++ b/lib/simp/cli/config/items/data/cli_network_interface.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_interface.rb
+++ b/lib/simp/cli/config/items/data/cli_network_interface.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_ipaddress.rb
+++ b/lib/simp/cli/config/items/data/cli_network_ipaddress.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_ipaddress.rb
+++ b/lib/simp/cli/config/items/data/cli_network_ipaddress.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_netmask.rb
+++ b/lib/simp/cli/config/items/data/cli_network_netmask.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_netmask.rb
+++ b/lib/simp/cli/config/items/data/cli_network_netmask.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_set_up_nic.rb
+++ b/lib/simp/cli/config/items/data/cli_network_set_up_nic.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_network_set_up_nic.rb
+++ b/lib/simp/cli/config/items/data/cli_network_set_up_nic.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_puppet_server_ip.rb
+++ b/lib/simp/cli/config/items/data/cli_puppet_server_ip.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_puppet_server_ip.rb
+++ b/lib/simp/cli/config/items/data/cli_puppet_server_ip.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_set_grub_password.rb
+++ b/lib/simp/cli/config/items/data/cli_set_grub_password.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_set_grub_password.rb
+++ b/lib/simp/cli/config/items/data/cli_set_grub_password.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_set_production_to_simp.rb
+++ b/lib/simp/cli/config/items/data/cli_set_production_to_simp.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_set_production_to_simp.rb
+++ b/lib/simp/cli/config/items/data/cli_set_production_to_simp.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_simp_scenario.rb
+++ b/lib/simp/cli/config/items/data/cli_simp_scenario.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_simp_scenario.rb
+++ b/lib/simp/cli/config/items/data/cli_simp_scenario.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_use_internet_simp_yum_repos.rb
+++ b/lib/simp/cli/config/items/data/cli_use_internet_simp_yum_repos.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/cli_use_internet_simp_yum_repos.rb
+++ b/lib/simp/cli/config/items/data/cli_use_internet_simp_yum_repos.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/grub_password.rb
+++ b/lib/simp/cli/config/items/data/grub_password.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../password_item', __dir__ )
+require_relative '../password_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/grub_password.rb
+++ b/lib/simp/cli/config/items/data/grub_password.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../password_item', File.dirname(__FILE__) )
+require File.expand_path( '../password_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/puppetdb_master_config_puppetdb_port.rb
+++ b/lib/simp/cli/config/items/data/puppetdb_master_config_puppetdb_port.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../integer_item', File.dirname(__FILE__) )
+require File.expand_path( '../integer_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/puppetdb_master_config_puppetdb_port.rb
+++ b/lib/simp/cli/config/items/data/puppetdb_master_config_puppetdb_port.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../integer_item', __dir__ )
+require_relative '../integer_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/puppetdb_master_config_puppetdb_server.rb
+++ b/lib/simp/cli/config/items/data/puppetdb_master_config_puppetdb_server.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/puppetdb_master_config_puppetdb_server.rb
+++ b/lib/simp/cli/config/items/data/puppetdb_master_config_puppetdb_server.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_openldap_server_conf_rootpw.rb
+++ b/lib/simp/cli/config/items/data/simp_openldap_server_conf_rootpw.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../password_item',  File.dirname(__FILE__) )
+require File.expand_path( '../password_item',  __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_openldap_server_conf_rootpw.rb
+++ b/lib/simp/cli/config/items/data/simp_openldap_server_conf_rootpw.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../password_item',  __dir__ )
+require_relative('../password_item')
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_dns_search.rb
+++ b/lib/simp/cli/config/items/data/simp_options_dns_search.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item', __dir__ )
+require_relative '../list_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_dns_search.rb
+++ b/lib/simp/cli/config/items/data/simp_options_dns_search.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item', File.dirname(__FILE__) )
+require File.expand_path( '../list_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_dns_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_dns_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item', __dir__ )
-require File.expand_path( '../../utils', __dir__ )
+require_relative '../list_item'
+require_relative '../../utils'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_dns_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_dns_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item', File.dirname(__FILE__) )
-require File.expand_path( '../../utils', File.dirname(__FILE__) )
+require File.expand_path( '../list_item', __dir__ )
+require File.expand_path( '../../utils', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_fips.rb
+++ b/lib/simp/cli/config/items/data/simp_options_fips.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_fips.rb
+++ b/lib/simp/cli/config/items/data/simp_options_fips.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_base_dn.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_base_dn.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_base_dn.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_base_dn.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_bind_dn.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_bind_dn.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_bind_dn.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_bind_dn.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_bind_hash.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_bind_hash.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../item',  __dir__ )
-require File.expand_path( '../../utils',  __dir__ )
+require_relative('../item')
+require_relative('../../utils')
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_bind_hash.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_bind_hash.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../item',  File.dirname(__FILE__) )
-require File.expand_path( '../../utils',  File.dirname(__FILE__) )
+require File.expand_path( '../item',  __dir__ )
+require File.expand_path( '../../utils',  __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_bind_pw.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_bind_pw.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../password_item',  __dir__ )
+require_relative '../password_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_bind_pw.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_bind_pw.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../password_item',  File.dirname(__FILE__) )
+require File.expand_path( '../password_item',  __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_master.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_master.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_master.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_master.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_root_dn.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_root_dn.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_root_dn.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_root_dn.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_sync_dn.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_sync_dn.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_sync_dn.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_sync_dn.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_sync_hash.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_sync_hash.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../item',  File.dirname(__FILE__) )
-require File.expand_path( '../../utils',  File.dirname(__FILE__) )
+require File.expand_path( '../item',  __dir__ )
+require File.expand_path( '../../utils',  __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_sync_hash.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_sync_hash.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../item',  __dir__ )
-require File.expand_path( '../../utils',  __dir__ )
+require_relative '../item'
+require_relative '../../utils'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_sync_pw.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_sync_pw.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../password_item', __dir__ )
+require_relative '../password_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_sync_pw.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_sync_pw.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../password_item', File.dirname(__FILE__) )
+require File.expand_path( '../password_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_uri.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_uri.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item', __dir__ )
+require_relative '../list_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ldap_uri.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ldap_uri.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item', File.dirname(__FILE__) )
+require File.expand_path( '../list_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item', __dir__ )
-require File.expand_path( '../../utils', __dir__ )
+require_relative '../list_item'
+require_relative '../../utils'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item', File.dirname(__FILE__) )
-require File.expand_path( '../../utils', File.dirname(__FILE__) )
+require File.expand_path( '../list_item', __dir__ )
+require File.expand_path( '../../utils', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_puppet_ca.rb
+++ b/lib/simp/cli/config/items/data/simp_options_puppet_ca.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_puppet_ca.rb
+++ b/lib/simp/cli/config/items/data/simp_options_puppet_ca.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_puppet_ca_port.rb
+++ b/lib/simp/cli/config/items/data/simp_options_puppet_ca_port.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../integer_item', File.dirname(__FILE__) )
+require File.expand_path( '../integer_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_puppet_ca_port.rb
+++ b/lib/simp/cli/config/items/data/simp_options_puppet_ca_port.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../integer_item', __dir__ )
+require_relative '../integer_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_puppet_server.rb
+++ b/lib/simp/cli/config/items/data/simp_options_puppet_server.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_puppet_server.rb
+++ b/lib/simp/cli/config/items/data/simp_options_puppet_server.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_sssd.rb
+++ b/lib/simp/cli/config/items/data/simp_options_sssd.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_sssd.rb
+++ b/lib/simp/cli/config/items/data/simp_options_sssd.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_syslog_failover_log_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_syslog_failover_log_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item',  File.dirname(__FILE__) )
-require File.expand_path( '../../utils', File.dirname(__FILE__) )
+require File.expand_path( '../list_item',  __dir__ )
+require File.expand_path( '../../utils', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_syslog_failover_log_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_syslog_failover_log_servers.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item',  __dir__ )
+require_relative '../list_item'
 require_relative '../../utils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/data/simp_options_syslog_failover_log_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_syslog_failover_log_servers.rb
@@ -1,5 +1,5 @@
 require File.expand_path( '../list_item',  __dir__ )
-require File.expand_path( '../../utils', __dir__ )
+require_relative '../../utils'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_syslog_log_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_syslog_log_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item',  File.dirname(__FILE__) )
-require File.expand_path( '../../utils', File.dirname(__FILE__) )
+require File.expand_path( '../list_item',  __dir__ )
+require File.expand_path( '../../utils', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_syslog_log_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_syslog_log_servers.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item',  __dir__ )
+require_relative '../list_item'
 require_relative '../../utils'
 
 module Simp; end

--- a/lib/simp/cli/config/items/data/simp_options_syslog_log_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_syslog_log_servers.rb
@@ -1,5 +1,5 @@
 require File.expand_path( '../list_item',  __dir__ )
-require File.expand_path( '../../utils', __dir__ )
+require_relative '../../utils'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_trusted_nets.rb
+++ b/lib/simp/cli/config/items/data/simp_options_trusted_nets.rb
@@ -1,6 +1,6 @@
 require 'ipaddr'
 require 'resolv'
-require File.expand_path( '../list_item', File.dirname(__FILE__) )
+require File.expand_path( '../list_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_options_trusted_nets.rb
+++ b/lib/simp/cli/config/items/data/simp_options_trusted_nets.rb
@@ -1,6 +1,6 @@
 require 'ipaddr'
 require 'resolv'
-require File.expand_path( '../list_item', __dir__ )
+require_relative '../list_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_run_level.rb
+++ b/lib/simp/cli/config/items/data/simp_run_level.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../integer_item', File.dirname(__FILE__) )
+require File.expand_path( '../integer_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_run_level.rb
+++ b/lib/simp/cli/config/items/data/simp_run_level.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../integer_item', __dir__ )
+require_relative '../integer_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_server_allow_simp_user.rb
+++ b/lib/simp/cli/config/items/data/simp_server_allow_simp_user.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_server_allow_simp_user.rb
+++ b/lib/simp/cli/config/items/data/simp_server_allow_simp_user.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_internet_simp_dependencies_class.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_internet_simp_dependencies_class.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../class_item', File.dirname(__FILE__) )
+require File.expand_path( '../class_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_internet_simp_dependencies_class.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_internet_simp_dependencies_class.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../class_item', __dir__ )
+require_relative '../class_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_class.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_class.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../class_item', File.dirname(__FILE__) )
+require File.expand_path( '../class_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_class.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_class.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../class_item', __dir__ )
+require_relative '../class_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_enable_repo.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_enable_repo.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_enable_repo.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_enable_repo.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item', __dir__ )
-require File.expand_path( '../../utils', __dir__ )
+require_relative '../list_item'
+require_relative '../../utils'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_os_updates_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item', File.dirname(__FILE__) )
-require File.expand_path( '../../utils', File.dirname(__FILE__) )
+require File.expand_path( '../list_item', __dir__ )
+require File.expand_path( '../../utils', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_simp_enable_repo.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_simp_enable_repo.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', File.dirname(__FILE__) )
+require File.expand_path( '../yes_no_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_simp_enable_repo.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_simp_enable_repo.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../yes_no_item', __dir__ )
+require_relative '../yes_no_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_simp_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_simp_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item', File.dirname(__FILE__) )
-require File.expand_path( '../../utils', File.dirname(__FILE__) )
+require File.expand_path( '../list_item', __dir__ )
+require File.expand_path( '../../utils', __dir__ )
 
 
 module Simp; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_local_simp_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_local_simp_servers.rb
@@ -1,5 +1,5 @@
-require File.expand_path( '../list_item', __dir__ )
-require File.expand_path( '../../utils', __dir__ )
+require_relative '../list_item'
+require_relative '../../utils'
 
 
 module Simp; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_simp_class.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_simp_class.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../class_item', File.dirname(__FILE__) )
+require File.expand_path( '../class_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/simp_yum_repo_simp_class.rb
+++ b/lib/simp/cli/config/items/data/simp_yum_repo_simp_class.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../class_item', __dir__ )
+require_relative '../class_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/sssd_domains.rb
+++ b/lib/simp/cli/config/items/data/sssd_domains.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item', __dir__ )
+require_relative '../list_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/sssd_domains.rb
+++ b/lib/simp/cli/config/items/data/sssd_domains.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item', File.dirname(__FILE__) )
+require File.expand_path( '../list_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/svckill_mode.rb
+++ b/lib/simp/cli/config/items/data/svckill_mode.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', __dir__ )
+require_relative '../item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/svckill_mode.rb
+++ b/lib/simp/cli/config/items/data/svckill_mode.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../item', File.dirname(__FILE__) )
+require File.expand_path( '../item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/useradd_securetty.rb
+++ b/lib/simp/cli/config/items/data/useradd_securetty.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item', __dir__ )
+require_relative '../list_item'
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/data/useradd_securetty.rb
+++ b/lib/simp/cli/config/items/data/useradd_securetty.rb
@@ -1,4 +1,4 @@
-require File.expand_path( '../list_item', File.dirname(__FILE__) )
+require File.expand_path( '../list_item', __dir__ )
 
 module Simp; end
 class Simp::Cli; end

--- a/lib/simp/cli/config/items/integer_item.rb
+++ b/lib/simp/cli/config/items/integer_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', File.dirname(__FILE__) )
+require File.expand_path( 'item', __dir__ )
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items/integer_item.rb
+++ b/lib/simp/cli/config/items/integer_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', __dir__ )
+require_relative 'item'
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items/list_item.rb
+++ b/lib/simp/cli/config/items/list_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', File.dirname(__FILE__) )
+require File.expand_path( 'item', __dir__ )
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items/list_item.rb
+++ b/lib/simp/cli/config/items/list_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', __dir__ )
+require_relative 'item'
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items/password_item.rb
+++ b/lib/simp/cli/config/items/password_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', File.dirname(__FILE__) )
+require File.expand_path( 'item', __dir__ )
 require 'simp/cli/utils'
 
 module Simp::Cli::Config

--- a/lib/simp/cli/config/items/password_item.rb
+++ b/lib/simp/cli/config/items/password_item.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'item', __dir__ )
+require_relative 'item'
 require 'simp/cli/utils'
 
 module Simp::Cli::Config

--- a/lib/simp/cli/config/items/yes_no_item.rb
+++ b/lib/simp/cli/config/items/yes_no_item.rb
@@ -1,7 +1,7 @@
 require 'highline/import'
 require 'puppet'
 require 'yaml'
-require File.expand_path( 'item', __dir__ )
+require_relative 'item'
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items/yes_no_item.rb
+++ b/lib/simp/cli/config/items/yes_no_item.rb
@@ -1,7 +1,7 @@
 require 'highline/import'
 require 'puppet'
 require 'yaml'
-require File.expand_path( 'item', File.dirname(__FILE__) )
+require File.expand_path( 'item', __dir__ )
 
 module Simp::Cli::Config
 

--- a/lib/simp/cli/config/items_yaml_generator.rb
+++ b/lib/simp/cli/config/items_yaml_generator.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'errors', File.dirname(__FILE__) )
+require File.expand_path( 'errors', __dir__ )
 require 'yaml'
 
 module Simp; end
@@ -9,7 +9,7 @@ module Simp::Cli::Config; end
 class Simp::Cli::Config::ItemsYamlGenerator
 
 
-  def initialize(scenario, scenarios_dir=File.join(File.dirname(__FILE__), 'scenarios'))
+  def initialize(scenario, scenarios_dir=File.join(__dir__, 'scenarios'))
     @scenario = scenario
     @scenarios_dir = scenarios_dir
   end

--- a/lib/simp/cli/config/items_yaml_generator.rb
+++ b/lib/simp/cli/config/items_yaml_generator.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'errors', __dir__ )
+require_relative 'errors'
 require 'yaml'
 
 module Simp; end

--- a/lib/simp/cli/config/questionnaire.rb
+++ b/lib/simp/cli/config/questionnaire.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'items', __dir__ )
+require_relative 'items'
 
 # Builds a SIMP configuration profile based on an Array of Config::Items
 #

--- a/lib/simp/cli/config/questionnaire.rb
+++ b/lib/simp/cli/config/questionnaire.rb
@@ -1,4 +1,4 @@
-require File.expand_path( 'items', File.dirname(__FILE__) )
+require File.expand_path( 'items', __dir__ )
 
 # Builds a SIMP configuration profile based on an Array of Config::Items
 #

--- a/spec/bin/simp_spec.rb
+++ b/spec/bin/simp_spec.rb
@@ -118,7 +118,7 @@ describe 'simp executable' do
     end
 
     it 'processes console input' do
-      stdin_file = File.join(__dir__, 'files', 'simp_config_full_stdin_file')
+      stdin_file = File.expand_path('files/simp_config_full_stdin_file', __dir__)
       results = execute("#{simp_exe} config #{@simp_config_args}", stdin_file)
       if results[:exitstatus] != 0
         puts '=============stdout===================='
@@ -135,7 +135,7 @@ describe 'simp executable' do
     end
 
     it 'gracefully handles console input termination' do
-      stdin_file = File.join(__dir__, 'files', 'simp_config_trunc_stdin_file')
+      stdin_file = File.expand_path('files/simp_config_trunc_stdin_file', __dir__)
       results = execute("#{simp_exe} config #{@simp_config_args}", stdin_file)
       expect(results[:exitstatus]).to eq 1
       expect(results[:stderr]).to match(/Input terminated! Exiting/)

--- a/spec/bin/simp_spec.rb
+++ b/spec/bin/simp_spec.rb
@@ -18,7 +18,7 @@ def execute(command, input_file = nil)
   exitstatus = $?.nil? ? nil : $?.exitstatus
   stdout = IO.read(stdout_file) if File.exists?(stdout_file)
   if File.exists?(stderr_file)
-    stderr_raw = IO.read(stderr_file) 
+    stderr_raw = IO.read(stderr_file)
     # WORKAROUND
     stderr = stderr_raw.split("\n").delete_if do |line|
       # When we are running this test on a system in which
@@ -72,17 +72,16 @@ end
 # - handles stdin termination signals appropriately
 # - outputs to stdout and stderr appropriately
 describe 'simp executable' do
-  let(:simp_exe) { File.join(__dir__, '..', '..', 'bin','simp') }
+  let(:simp_exe) { File.expand_path('../../bin/simp', __dir__) }
 
   before :all do
-    env_files_dir = File.join(__dir__, '..', 'lib', 'simp',
-      'cli', 'commands', 'files')
-    code_dir = File.join(ENV['HOME'], '.puppetlabs', 'etc', 'code')
+    env_files_dir = File.expand_path('../lib/simp/cli/commands/files', __dir__)
+    code_dir = File.expand_path('.puppetlabs/etc/code',ENV['HOME'])
     @test_env_dir = File.join(code_dir, 'environments')
     FileUtils.mkdir_p(@test_env_dir)
 
 # FIXME without :verbose option, copy doesn't copy all....
-    FileUtils.cp_r(File.join(env_files_dir, 'environments', 'simp'), @test_env_dir, :verbose => true)
+    FileUtils.cp_r(File.expand_path('environments/simp', env_files_dir), @test_env_dir, :verbose => true)
   end
 
   before :each do

--- a/spec/bin/simp_spec.rb
+++ b/spec/bin/simp_spec.rb
@@ -72,10 +72,10 @@ end
 # - handles stdin termination signals appropriately
 # - outputs to stdout and stderr appropriately
 describe 'simp executable' do
-  let(:simp_exe) { File.join(File.dirname(__FILE__), '..', '..', 'bin','simp') }
+  let(:simp_exe) { File.join(__dir__, '..', '..', 'bin','simp') }
 
   before :all do
-    env_files_dir = File.join(File.dirname(__FILE__), '..', 'lib', 'simp',
+    env_files_dir = File.join(__dir__, '..', 'lib', 'simp',
       'cli', 'commands', 'files')
     code_dir = File.join(ENV['HOME'], '.puppetlabs', 'etc', 'code')
     @test_env_dir = File.join(code_dir, 'environments')
@@ -119,7 +119,7 @@ describe 'simp executable' do
     end
 
     it 'processes console input' do
-      stdin_file = File.join(File.dirname(__FILE__), 'files', 'simp_config_full_stdin_file')
+      stdin_file = File.join(__dir__, 'files', 'simp_config_full_stdin_file')
       results = execute("#{simp_exe} config #{@simp_config_args}", stdin_file)
       if results[:exitstatus] != 0
         puts '=============stdout===================='
@@ -136,7 +136,7 @@ describe 'simp executable' do
     end
 
     it 'gracefully handles console input termination' do
-      stdin_file = File.join(File.dirname(__FILE__), 'files', 'simp_config_trunc_stdin_file')
+      stdin_file = File.join(__dir__, 'files', 'simp_config_trunc_stdin_file')
       results = execute("#{simp_exe} config #{@simp_config_args}", stdin_file)
       expect(results[:exitstatus]).to eq 1
       expect(results[:stderr]).to match(/Input terminated! Exiting/)

--- a/spec/lib/simp/cli/commands/bootstrap_spec.rb
+++ b/spec/lib/simp/cli/commands/bootstrap_spec.rb
@@ -1,7 +1,7 @@
 require 'simp/cli/commands/bootstrap'
 
 describe 'Simp::Cli::Command::Bootstrap#run' do
-  let(:files_dir) { File.join(File.dirname(__FILE__), 'files') }
+  let(:files_dir) { File.join(__dir__, 'files') }
 
   before(:each) do
     @tmp_dir  = Dir.mktmpdir( File.basename(__FILE__) )

--- a/spec/lib/simp/cli/commands/config_read_answers_file_spec.rb
+++ b/spec/lib/simp/cli/commands/config_read_answers_file_spec.rb
@@ -5,7 +5,7 @@ require 'set'
 require 'yaml'
 
 describe 'Simp::Cli::Commands::Config#read_answers_file' do
-  let(:files_dir) { File.join(File.dirname(__FILE__), 'files') }
+  let(:files_dir) { File.join(__dir__, 'files') }
 
   before(:each) do
     @tmp_dir  = Dir.mktmpdir( File.basename(__FILE__) )

--- a/spec/lib/simp/cli/commands/config_run_spec.rb
+++ b/spec/lib/simp/cli/commands/config_run_spec.rb
@@ -15,7 +15,7 @@ require 'yaml'
 #       calls are wrapped in a Timeout block.
 
 describe 'Simp::Cli::Command::Config#run' do
-  let(:files_dir) { File.join(File.dirname(__FILE__), 'files') }
+  let(:files_dir) { File.join(__dir__, 'files') }
   let(:max_config_run_seconds) { 60 }
 
   before(:each) do

--- a/spec/lib/simp/cli/config/items/action/copy_simp_to_environments_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/copy_simp_to_environments_action_spec.rb
@@ -33,7 +33,7 @@ describe Simp::Cli::Config::Item::CopySimpToEnvironmentsAction do
       @ci.adapter_config = @adapter_config
       @ci.source_dir = @source_dir
       @ci.dest_dir = @dest_dir
-      @ci.copy_script = File.join(File.dirname(__FILE__), 'files', 'simp_adapter',
+      @ci.copy_script = File.join(__dir__, 'files', 'simp_adapter',
         'mock_simp_rpm_helper.rb')
     end
 

--- a/spec/lib/simp/cli/config/items/action/set_site_scenario_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/set_site_scenario_action_spec.rb
@@ -3,8 +3,8 @@ require 'simp/cli/config/items/data/cli_simp_scenario'
 require_relative '../spec_helper'
 
 describe Simp::Cli::Config::Item::SetSiteScenarioAction do
-  let(:files_dir) { File.join(File.dirname(__FILE__), 'files') }
-  let(:env_files_dir) { File.join(File.dirname(__FILE__), '..', '..', '..', 'commands', 'files') }
+  let(:files_dir) { File.join(__dir__, 'files') }
+  let(:env_files_dir) { File.join(__dir__, '..', '..', '..', 'commands', 'files') }
 
   before :each do
     @tmp_dir = Dir.mktmpdir( File.basename( __FILE__ ) )

--- a/spec/lib/simp/cli/config/items/data/cli_simp_scenario_spec.rb
+++ b/spec/lib/simp/cli/config/items/data/cli_simp_scenario_spec.rb
@@ -14,7 +14,7 @@ describe Simp::Cli::Config::Item::CliSimpScenario do
   end
 
   context '#os_value' do
-    let(:env_files_dir) { File.join(File.dirname(__FILE__), '..', '..', '..', 'commands', 'files') }
+    let(:env_files_dir) { File.join(__dir__, '..', '..', '..', 'commands', 'files') }
 
     before :each do
       @tmp_dir = Dir.mktmpdir( File.basename( __FILE__ ) )

--- a/spec/lib/simp/cli/config/items/data/cli_simp_scenario_spec.rb
+++ b/spec/lib/simp/cli/config/items/data/cli_simp_scenario_spec.rb
@@ -14,7 +14,7 @@ describe Simp::Cli::Config::Item::CliSimpScenario do
   end
 
   context '#os_value' do
-    let(:env_files_dir) { File.join(__dir__, '..', '..', '..', 'commands', 'files') }
+    let(:env_files_dir) { File.expand_path('../../../commands/files', __dir__) }
 
     before :each do
       @tmp_dir = Dir.mktmpdir( File.basename( __FILE__ ) )

--- a/spec/lib/simp/cli/config/items_yaml_generator_spec.rb
+++ b/spec/lib/simp/cli/config/items_yaml_generator_spec.rb
@@ -3,7 +3,7 @@ require 'rspec/its'
 require 'spec_helper'
 
 describe Simp::Cli::Config::ItemsYamlGenerator do
-  let (:files_dir) { File.join(File.dirname(__FILE__), 'files') }
+  let (:files_dir) { File.join(__dir__, 'files') }
   describe "#generate_yaml" do
     it 'constructs YAML from parts and substitutes variables' do
       expected = IO.read(File.join(files_dir, 'simp_generated_items_tree.yaml'))

--- a/spec/lib/simp/cli/utils_spec.rb
+++ b/spec/lib/simp/cli/utils_spec.rb
@@ -18,7 +18,7 @@ describe Simp::Cli::Utils do
   end
 
   describe '.get_stock_simp_env_datadir' do
-    let(:files_dir) { File.join(File.dirname(__FILE__), 'commands', 'files') }
+    let(:files_dir) { File.join(__dir__, 'commands', 'files') }
     before(:each) do
       @tmp_dir  = Dir.mktmpdir( File.basename(__FILE__) )
       @test_env_dir = File.join(@tmp_dir, 'environments')

--- a/spec/lib/simp/cli_spec.rb
+++ b/spec/lib/simp/cli_spec.rb
@@ -11,7 +11,7 @@ describe 'Simp::Cli' do
   end
 
   before(:each) do
-    files_dir = File.join(File.dirname(__FILE__), 'cli', 'commands', 'files')
+    files_dir = File.join(__dir__, 'cli', 'commands', 'files')
     @tmp_dir  = Dir.mktmpdir( File.basename(__FILE__) )
     test_env_dir = File.join(@tmp_dir, 'environments')
     simp_env_dir = File.join(test_env_dir, 'simp')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ end
 
 RSpec.configure do |config|
 
-  $LOAD_PATH.unshift(File.expand_path( '../lib', File.dirname(__FILE__) ))
+  $LOAD_PATH.unshift(File.expand_path( '../lib', __dir__ ))
 
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
This patch modernizes outdated Ruby idioms established in previous
versions on simp-cli in order to maintain compatibility with Ruby 1.8
and 1.9.  These can be simplified now that the minimum Ruby version is
2.1.9.

The modernizations mainly focus on two things:

* `require_relative` (introduced in Ruby 1.9)
*  `__dir__` (introduced in Ruby 2.0), instead of
   `File.dirname(__FILE__)`
