### PR TITLE
(SIMP-6205) Ensure puppet.your.domain.yaml exists during `simp config`

### DIFF
--- a/lib/simp/cli/config/items/action/create_simp_server_fqdn_yaml_action.rb
+++ b/lib/simp/cli/config/items/action/create_simp_server_fqdn_yaml_action.rb
@@ -31,8 +31,8 @@ module Simp::Cli::Config
         #     (e.g., tries to fix a typo by running again).
         @extra_host_yaml = Dir.glob(File.join(File.dirname(@host_yaml), '*.yaml'))
 
-        @extra_host_yaml.each do |file|
-                backup_host_yaml(file)
+        @extra_host_yaml.each do |extra_yaml|
+                backup_host_yaml(extra_yaml)
         end
 
         FileUtils.cp(@alt_file, @template_file)
@@ -96,7 +96,6 @@ Review and consider updating:
       'Creation of ' +
         "#{@host_yaml ? File.basename(@host_yaml) : 'SIMP server <host>.yaml'} #{@applied_status.to_s}" +
         "#{@applied_status_detail ? ":\n    #{@applied_status_detail}" : ''}"
-        "#{@extra_host_yaml ? "#{@extra_host_yaml.size} "'extra <host>.yaml files exist!' : ''}"
     end
 
     def backup_host_yaml(yaml_file)


### PR DESCRIPTION
The definition of @alt_file was modified to add '/' as the first
parameter in File.join(). This fixes the original issue of
puppet.your.domain.yaml not existing on a second run of `simp config`

This fix caused the potential for `simp config` to create multiple,
potentially valid, <host>.yaml files. Instead of deleting .yaml files,
they are backed up and the number of backed up files is reported at the
end of the `simp config` in the summary.

backup_host_yaml() was modified to accept a filename variable. The
module now detects all existing .yaml files and backs them up in the
same way that <host>.yaml was backed up before.

apply_summary was modified to report that extra <host>.yaml files exist
during the post `simp config` summary.