### PR TITLE
Allow simp bootstrap to complete successfully

### DIFF
--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -116,6 +116,10 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
     linecounts << track_output("#{pupcmd} --tags pupmod,simp 2> /dev/null", pup_port)
 
     fix_file_contexts
+    
+    # After the first run the puppetserver will normally come up on a different port, 
+    # reloading puppetserver to apply this change
+    execute('puppetserver reload')
 
     # SIMP is not single-run idempotent.  Until it is, run puppet twice.
     info('Running puppet without tags', 'cyan')

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -12,6 +12,8 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
 
   def initialize
 
+    ENV['PATH'] = '/opt/puppetlabs/bin:' + ENV['PATH']
+
     @is_pe = Simp::Cli::Utils.puppet_info[:is_pe]
 
     @puppetserver_service = 'puppetserver'

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -87,11 +87,6 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
     end
 
     # Reload the puppetserver
-    #
-    # TODO: Validate that the pupmod-simp-pupmod tests are properly checking
-    # for the server restart with a port switch. This has not traditionally
-    # been a problem and having this statement does no harm but it should not
-    # be required.
     execute('puppetserver reload')
 
     # - Firstrun is tagged and run against the bootstrap puppetserver port.
@@ -123,9 +118,14 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
     linecounts << track_output("#{pupcmd} --tags pupmod,simp 2> /dev/null", pup_port)
 
     fix_file_contexts
-    
-    # After the first run the puppetserver will normally come up on a different port, 
+
+    # After the first run the puppetserver will normally come up on a different port,
     # reloading puppetserver to apply this change
+    #
+    # TODO: Validate that the pupmod-simp-pupmod tests are properly checking
+    # for the server restart with a port switch. This has not traditionally
+    # been a problem and having this statement does no harm but it should not
+    # be required.
     execute('puppetserver reload')
 
     # SIMP is not single-run idempotent.  Until it is, run puppet twice.

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -87,6 +87,11 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
     end
 
     # Reload the puppetserver
+    #
+    # TODO: Validate that the pupmod-simp-pupmod tests are properly checking
+    # for the server restart with a port switch. This has not traditionally
+    # been a problem and having this statement does no harm but it should not
+    # be required.
     execute('puppetserver reload')
 
     # - Firstrun is tagged and run against the bootstrap puppetserver port.


### PR DESCRIPTION
Bootstrap has been failing on my systems (RedHat, SIMP EE 6.3) due to the fact that the puppetserver is never reloaded after the port changes to 8140. This adds a reload after the first puppet run so the puppetserver actually restarts and comes up successfully on the correct port.