### PR TITLE
SIMP-6205 simp config fails template copy when hostname is changed

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -126,6 +126,13 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Wed Mar 20 2019 Jim Anderson <thesemicolons@protonmail.com> - 4.5.0
+- Fixed bug in which 'simp config' failed to find the template
+  SIMP server host YAML file, puppet.your.domain.yaml, from
+  /usr/share simp/enviornments/simp.  This bug caused subsequent
+  'simp config' runs to fail, when the SIMP server hostname had
+  changed from the hostname used in the first 'simp config' run.
+
 * Mon Mar 18 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.5.0
 - Ensure that an FQDN is used when running `simp config`
 - Ensure that an FQDN is set when running `simp bootstrap`

--- a/lib/simp/cli/config/items/action/create_simp_server_fqdn_yaml_action.rb
+++ b/lib/simp/cli/config/items/action/create_simp_server_fqdn_yaml_action.rb
@@ -29,10 +29,10 @@ module Simp::Cli::Config
         # (1) RPM/ISO install (so /usr/share/simp exists)
         # (2) Operator runs simp config more than once but with different hostnames
         #     (e.g., tries to fix a typo by running again).
-        @extra_host_yaml = Dir.glob(File.join(File.dirname(@host_yaml), '*.yaml'))
+        extra_host_yaml = Dir.glob(File.join(File.dirname(@host_yaml), '*.yaml'))
 
-        @extra_host_yaml.each do |extra_yaml|
-            debug("Extra <host>.yaml file found! #{extra_yaml}")
+        extra_host_yaml.each do |extra_yaml|
+            debug("Other <host>.yaml file found: #{extra_yaml}")
         end
 
         FileUtils.cp(@alt_file, @template_file)

--- a/lib/simp/cli/config/items/action/create_simp_server_fqdn_yaml_action.rb
+++ b/lib/simp/cli/config/items/action/create_simp_server_fqdn_yaml_action.rb
@@ -12,7 +12,7 @@ module Simp::Cli::Config
       @description = 'Create SIMP server <host>.yaml from template'
       @die_on_apply_fail = true
       @template_file = File.join(Simp::Cli::Utils.simp_env_datadir, 'hosts', 'puppet.your.domain.yaml')
-      @alt_file    = File.join('usr', 'share', 'simp', 'environments', 'simp',
+      @alt_file    = File.join('/', 'usr', 'share', 'simp', 'environments', 'simp',
         File.basename(Simp::Cli::Utils.simp_env_datadir), 'hosts', 'puppet.your.domain.yaml')
       @host_yaml    = nil
       @group       = Simp::Cli::Utils.puppet_info[:puppet_group]

--- a/lib/simp/cli/config/items/action/create_simp_server_fqdn_yaml_action.rb
+++ b/lib/simp/cli/config/items/action/create_simp_server_fqdn_yaml_action.rb
@@ -29,6 +29,12 @@ module Simp::Cli::Config
         # (1) RPM/ISO install (so /usr/share/simp exists)
         # (2) Operator runs simp config more than once but with different hostnames
         #     (e.g., tries to fix a typo by running again).
+        @extra_host_yaml = Dir.glob(File.join(File.dirname(@host_yaml), '*.yaml'))
+
+        @extra_host_yaml.each do |extra_yaml|
+            debug("Extra <host>.yaml file found! #{extra_yaml}")
+        end
+
         FileUtils.cp(@alt_file, @template_file)
       end
       debug( "Creating #{File.basename(@host_yaml)} from #{File.basename(@template_file)} template" )


### PR DESCRIPTION
Fixed file path for @alt_file, and added code to list existing <host>.yaml files to the debug() log.