### PR TITLE
(SIMP-5156) Added message regarding puppetserver port change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,13 +28,10 @@ before_install:
 
 
 jobs:
-  allow_failures:
-    - name: 'Ruby packaged with Puppet 6.x (allowed to fail)'
-
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.4
+      rvm: 2.4.5
       script:
         - bundle exec rake pkg:compare_latest_tag
         - bundle exec rake pkg:create_tag_changelog
@@ -42,17 +39,8 @@ jobs:
 
     # Test with Ruby versions packaged with standard Puppet All-in-one installs
     - stage: spec
-      name: 'Ruby packaged with Puppet 4.x'
-      rvm: 2.1.9
-      env:
-        - PUPPET_VERSION="~> 4.10"
-        - SIMP_SKIP_NON_SIMPOS_TESTS=1
-      script:
-        - bundle exec rake spec
-
-    - stage: spec
       name: 'Ruby packaged with Puppet 5.x'
-      rvm: 2.4.4
+      rvm: 2.4.5
       env:
         - PUPPET_VERSION="~> 5.5"
         - SIMP_SKIP_NON_SIMPOS_TESTS=1
@@ -60,7 +48,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: spec
-      name: 'Ruby packaged with Puppet 6.x (allowed to fail)'
+      name: 'Ruby packaged with Puppet 6.x'
       rvm: 2.5.1
       env:
         - PUPPET_VERSION="~> 6.0"
@@ -69,7 +57,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.4.4
+      rvm: 2.4.5
       script:
         - true
       before_deploy:

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -126,6 +126,11 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Wed Apr 03 2019 Jim Anderson <thesemicolons@protonmail.com> - 4.5.0
+- Added message to bootstrap.rb indicating that puppetserver has been
+  reconfigured to listen on a specific port. This message will be
+  displayed if the port is changed to 8140, or if it remains on 8150.
+
 * Wed Mar 20 2019 Jim Anderson <thesemicolons@protonmail.com> - 4.5.0
 - Fixed bug in which 'simp config' failed to find the template
   SIMP server host YAML file, puppet.your.domain.yaml, from

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -107,6 +107,8 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
       pup_port = '8150'
     end
 
+    info("Configuring the puppetserver to listen on port #{pup_port}", 'cyan')
+
     pupcmd = "puppet agent --onetime --no-daemonize --no-show_diff --verbose" +
       " --no-splay --agent_disabled_lockfile=#{agent_lockfile}" +
       " --masterport=#{pup_port} --ca_port=#{pup_port}"


### PR DESCRIPTION
Added message to bootstrap.rb indicating that puppetserver has been
reconfigured to listen on a specific port. This message will be
displayed if the port is changed to 8140, or if it remains on 8150.