### PR TITLE
(SIMP-6628) simp bootstrap:2 tagged runs required

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -183,6 +183,7 @@ EOM
   - Fixed a bug in which the check for Puppet Enterprise was
     incorrect.  This would result in Puppet FOSS-specific bootstrap
     operations being executed.
+  - Added an additional puppet agent tagged run on the bootstrap port
   - Added more log messages to make bootstrap process more clear
 
 * Wed Apr 03 2019 Jim Anderson <thesemicolons@protonmail.com> - 5.0.0


### PR DESCRIPTION
The cleanup of the %post sections of the SIMP asset RPMs
now requires `simp bootstrap` to execute more than 1 tagged
run on the bootstrap port.

The specific problem was the permissions on
/opt/puppetlabs/puppet/cache/pdb_tmp.

SIMP-6628