### PR TITLE
(SIMP-6622) simp config automatic setting message incorrect

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -156,10 +156,6 @@ EOM
       of actions makes sense to the user.
   - Improved introductory text and descriptions of a few items
     that have been confusing for users
-  - In the answers YAML file, provide an 'automatically set'
-    comment for each an Item for which 'simp config' generates
-    the answer. Thes are items that a user cannot preconfigure
-    in an input answers file.
   - Removed the ability for a non-root user to set the Puppet
     digest algorithm.  This was a bug.
   - In cli::network::interface item, try to recommend an

--- a/lib/simp/cli/config/items/action/answers_yaml_file_writer.rb
+++ b/lib/simp/cli/config/items/action/answers_yaml_file_writer.rb
@@ -40,21 +40,14 @@ module Simp::Cli::Config
                      # NOTE:
                      # - All YAML keys that begin with 'cli::' are used by
                      #   simp config, internally, and are not Puppet hieradata.
-                     #
-                     # - Any entry with the following comment is automatically,
-                     #   silently set by `simp config`.
-                     #
-                     #     #{Item.new.auto_warning}
-                     #
-                     #   This means if you modify any of these entries in
-                     #   an answers file, and then feed that file back into
-                     #   `simp config`, your modifications will be lost!
+                     # - Some entries have been automatically determined by
+                     #   `simp config` based on the values of other entries
+                     #   and/or gathered server status.
                      ".gsub(/^\s+/, '').strip
       iostream.puts "#" + '='*72
       iostream.puts '---'
       iostream.puts '# === cli::version ==='
       iostream.puts '# The version of simp-cli used to generate this file.'
-      iostream.puts "# #{Item.new.auto_warning}"
       iostream.puts "cli::version: \"#{Simp::Cli::VERSION}\""
       iostream.puts
 
@@ -64,7 +57,7 @@ module Simp::Cli::Config
 
       answers.each do |k,v|
         if v.data_type and v.data_type != :internal
-          if yaml = v.to_yaml_s(true)  # filter out nil results for items whose YAML is suppressed
+          if yaml = v.to_yaml_s  # filter out nil results for items whose YAML is suppressed
             # get rid of trailing whitespace
             yaml.split("\n").each { |line| iostream.puts line.rstrip }
             iostream.puts

--- a/spec/lib/simp/cli/config/items/action/files/answers_yaml_file_writer.yaml
+++ b/spec/lib/simp/cli/config/items/action/files/answers_yaml_file_writer.yaml
@@ -13,20 +13,13 @@
 # NOTE:
 # - All YAML keys that begin with 'cli::' are used by
 #   simp config, internally, and are not Puppet hieradata.
-#
-# - Any entry with the following comment is automatically,
-#   silently set by `simp config`.
-#
-#     >> VALUE SET BY `simp config` AUTOMATICALLY. <<
-#
-#   This means if you modify any of these entries in
-#   an answers file, and then feed that file back into
-#   `simp config`, your modifications will be lost!
+# - Some entries have been automatically determined by
+#   `simp config` based on the values of other entries
+#   and/or gathered server status.
 #========================================================================
 ---
 # === cli::version ===
 # The version of simp-cli used to generate this file.
-# >> VALUE SET BY `simp config` AUTOMATICALLY. <<
 cli::version: "0.0.0"
 
 # === cli::network::hostname ===


### PR DESCRIPTION
Disable marking entries as 'automatically set' in the answers
YAML file as this notation is incorrect when an answers file
is used as input to 'simp config'.

SIMP-6622 #close