### PR TITLE
(SIMP-6632) Warn on simp config --force-config

### DIFF
--- a/lib/simp/cli/config/items/data/simp_options_dns_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_dns_servers.rb
@@ -16,14 +16,14 @@ If the first entry of this list is set to '127.0.0.1', then
 all clients will configure themselves as caching DNS servers
 pointing to the other entries in the list.
 
-If you have a system that's including the 'named' class and
-is *not* in this list, then you'll need to set a variable at
-the top of that node entry called $named_server to 'true'.
-This will get around the convenience logic that was put in
-place to handle the caching entries and will not attempt to
-convert your system to a caching DNS server. You'll know
-that you have this situation if you end up with a duplicate
-definition for File['/etc/named.conf'].}
+If you are using the SIMP ``resolv`` module, and the system is a DNS server
+using the SIMP ``named`` module but you wish to have your node point to a
+different DNS server for primary DNS resolution, then you MUST set
+``resolv::named_server`` to ``true`` via Hiera.
+
+This will get around the convenience logic that was put in place to handle
+the caching entries and will not attempt to convert your system to a
+caching DNS server.}
       @file = '/etc/resolv.conf'
     end
 

--- a/lib/simp/cli/logging.rb
+++ b/lib/simp/cli/logging.rb
@@ -102,6 +102,23 @@ module Simp::Cli::Logging
       end
     end
 
+    # pause for the specified number of seconds, printing a countdown
+    # message to the console every second
+    # +pause_seconds+: Number of seconds to pause
+    # +pre_txt+: Text to prepend to the current count in the console message
+    # +post_txt+: Text to append to the current count in the console message
+    def count_down(pause_seconds, pre_txt='', post_txt='')
+      count = pause_seconds
+      max_len = count.to_s.size
+      while count > 0
+        $stdout.printf("...#{pre_txt}%#{max_len}d#{post_txt}", count)
+        sleep(1)
+        $stdout.write("\r")
+        count -= 1
+      end
+      $stdout.printf("...#{pre_txt}%#{max_len}d#{post_txt}\n", 0)
+    end
+
    # pause log output to allow message of
    # message_level to be viewed on the console
     def pause(message_level, pause_seconds)

--- a/spec/lib/simp/cli/logging_spec.rb
+++ b/spec/lib/simp/cli/logging_spec.rb
@@ -168,5 +168,21 @@ EOM
       end
     end
   end
+
+  describe 'count_down' do
+    it 'should print generic countdown message to the console' do
+      # exact match doesn't work in TravisCI
+      expected = /\.\.\.2.*\.\.\.1.*\.\.\.0\n/
+      expect{ MyLogTesterA.logger.count_down(2) }.to output(expected).to_stdout
+      expect{ MyLogTesterB.new.logger.count_down(2) }.to output(expected).to_stdout
+    end
+
+    it 'should print customized countdown message to the console' do
+      # exact match doesn't work in TravisCI
+      expected = /\.\.\.Resuming in 2 seconds.*\.\.\.Resuming in 1 seconds.*\.\.\.Resuming in 0 seconds\n/
+      expect{ MyLogTesterA.logger.count_down(2, 'Resuming in ', ' seconds') }.to output(expected).to_stdout
+      expect{ MyLogTesterB.new.logger.count_down(2, 'Resuming in ', ' seconds') }.to output(expected).to_stdout
+    end
+  end
 end
 


### PR DESCRIPTION
- Warn user to backup their Puppet environment prior
  to running `simp config --force-config` on an existing
  SIMP omni-environment
- Specify the full simp command required for --force-config
- Fix bad description for simp_options::dns::servers
- Don't fail `simp config` because of an existing SIMP
  omni-environment, when the user is continuing an interrupted
  session (a session in which at least *one* configuration value
  was gathered from the user).  `simp config` will still fail a
  subsequent run if the user didn't enter the questionnaire but
  *did* allow the SIMP omni-environment to be created....Fixing
  this specific case requires a bigger structural change to the code.

SIMP-6544 #close
SIMP-6632 #close