### PR TITLE
(SIMP-MAINT) Improve top level help

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -127,6 +127,12 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Tue Jun 04 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0
+- 'simp' change:
+  - Standardized help mechanism to be -h at all levels
+    (main, command, subcommand)
+  - Added descriptions to top level help command list
+
 * Fri Apr 26 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0
 - New features:
   - Added 'simp environment' command

--- a/lib/simp/cli.rb
+++ b/lib/simp/cli.rb
@@ -15,25 +15,21 @@ module Simp; end
 # namespace for SIMP CLI commands
 class Simp::Cli
   def self.menu
-    puts 'Usage: simp [command]'
+    puts 'SIMP Command Line Interface'
     puts
-    puts '  Commands'
-    @commands.keys.sort.each do |command_name|
-      puts "    - #{command_name}"
-    end
-    puts '    - help [command]'
+    puts 'Usage:'
     puts
-  end
-
-  def self.version
-    cmd = 'rpm -q simp'
-    begin
-      `#{cmd}`.split(/\n/).last.match(/([0-9]+\.[0-9]+\.?[0-9]*)/)[1]
-    rescue
-      #TODO Send this message to stderr instead of stdout?
-      msg = "Cannot find SIMP OS installation via `#{cmd}`!"
-      say 'WARNING: '.bold.yellow + msg.yellow
+    puts ' simp -h'
+    puts ' simp COMMAND -h'
+    puts ' simp COMMAND [command options]'
+    puts
+    puts 'COMMANDS'
+    command_array = @commands.sort
+    max_length = command_array.map { |command, command_obj| command.length }.max
+    command_array.each do |command, command_obj|
+      puts "  #{command.ljust(max_length, ' ')}   #{command_obj.description}"
     end
+    puts
   end
 
   def self.start(args = ARGV)
@@ -46,23 +42,15 @@ class Simp::Cli
         @commands[constant.to_s.downcase] = obj.new
       end
     end
-    @commands['version'] = self
 
     result = 0
-    if args.length == 0 or (args.length == 1 and args[0] == 'help')
+    help_args = [
+      '-h',
+      '--help'
+    ]
+    if args.length == 0 || args[0] == 'help' ||
+        (args.length == 1 && help_args.include?(args[0]))
       menu
-    elsif args[0] == 'version'
-      puts version
-    elsif args[0] == 'help'
-      if (command = @commands[args[1]]).nil?
-        $stderr.puts "\n#{args[1]} is not a recognized command\n\n".red
-        menu
-        result = 1
-      elsif args[1] == 'version'
-        puts 'Display the current version of SIMP.'
-      else
-        command.help
-      end
     elsif (command = @commands[args[0]]).nil?
       $stderr.puts "\n#{args[0]} is not a recognized command\n\n".red
       menu

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -30,6 +30,10 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
   #####################################################
   # Simp::Cli::Commands::Command API methods
   #####################################################
+  #
+  def description
+    'Bootstrap initial SIMP server'
+  end
 
   def help
     parse_command_line( [ '--help' ] )

--- a/lib/simp/cli/commands/command.rb
+++ b/lib/simp/cli/commands/command.rb
@@ -13,6 +13,13 @@ module Simp::Cli::Commands; end
 # implement a help() method and a run() method.
 class Simp::Cli::Commands::Command
 
+  # Brief description.
+  # Should be < 65 characters in length to avoid wrapping on the console.
+  # The derived class must implement this method
+  def description
+    raise("description() not implemented by #{self.class} ")
+  end
+
   # The derived class must implement this method and raise
   # an exception upon failure.
   def help

--- a/lib/simp/cli/commands/config.rb
+++ b/lib/simp/cli/commands/config.rb
@@ -92,6 +92,10 @@ EOM
   #####################################################
   # Simp::Cli::Commands::Command API methods
   #####################################################
+  #
+  def description
+    'Prepare SIMP server for bootstrapping'
+  end
 
   def help
     parse_command_line( [ '--help' ] )

--- a/lib/simp/cli/commands/doc.rb
+++ b/lib/simp/cli/commands/doc.rb
@@ -2,11 +2,25 @@ require 'simp/cli/commands/command'
 
 class Simp::Cli::Commands::Doc < Simp::Cli::Commands::Command
 
-  def help
-    puts "\n=== The SIMP Doc Tool ===\nShow SIMP documentation in elinks, a text-based web browser"
+  def description
+    'Show SIMP documentation in elinks'
   end
 
-  def run(unused_args = [])
+  def help
+    puts <<EOM
+
+=== The SIMP Doc Tool ===
+Show SIMP documentation in elinks, a text-based web browser
+
+Usage:  simp doc
+
+EOM
+  end
+
+  def run(args)
+    parse_command_line(args)
+    return if @help_requested
+
     unless system("rpm -q --quiet simp-doc")
       err_msg = "Package 'simp-doc' is not installed, cannot continue."
       raise Simp::Cli::ProcessingError.new(err_msg)
@@ -20,5 +34,14 @@ class Simp::Cli::Commands::Doc < Simp::Cli::Commands::Command
     end
 
     exec("links #{main_page}")
+  end
+
+  def parse_command_line(args)
+    if args.include?('-h') or args.include?('--help')
+      help
+      @help_requested = true
+    elsif args.size > 0
+      raise OptionParser::ParseError.new("Unsupported option: #{args.first}")
+    end
   end
 end

--- a/lib/simp/cli/commands/passgen.rb
+++ b/lib/simp/cli/commands/passgen.rb
@@ -15,6 +15,10 @@ class Simp::Cli::Commands::Passgen < Simp::Cli::Commands::Command
     @force_remove = false
   end
 
+  def description
+    "Utility for managing 'passgen' passwords"
+  end
+
   def help
     parse_command_line( [ '--help' ] )
   end

--- a/lib/simp/cli/commands/version.rb
+++ b/lib/simp/cli/commands/version.rb
@@ -16,20 +16,11 @@ class Simp::Cli::Commands::Version < Simp::Cli::Commands::Command
 
     cmd = 'rpm -q simp'
     begin
-      `#{cmd}`.split(/\n/).last.match(/([0-9]+\.[0-9]+\.?[0-9]*)/)[1]
+      puts `#{cmd}`.split(/\n/).last.match(/([0-9]+\.[0-9]+\.?[0-9]*)/)[1]
     rescue
-      #TODO Send this message to stderr instead of stdout?
       msg = 'Version unknown:'
       msg += "  Cannot find SIMP OS installation via `#{cmd}`!"
-      puts msg
-    end
-  end
-  def parse_command_line(args)
-    if args.include?('-h') or args.include?('--help')
-      help
-      @help_requested = true
-    elsif args.size > 0
-      raise OptionParser::ParseError.new("Unsupported option: #{args.first}")
+      raise Simp::Cli::ProcessingError.new(msg)
     end
   end
 

--- a/lib/simp/cli/commands/version.rb
+++ b/lib/simp/cli/commands/version.rb
@@ -1,0 +1,45 @@
+require 'simp/cli/commands/command'
+
+class Simp::Cli::Commands::Version < Simp::Cli::Commands::Command
+
+  def description
+    'Display the current version of SIMP.'
+  end
+
+  def help
+    puts "\n#{description}\n\nUsage:  simp version\n"
+  end
+
+  def run(args)
+    parse_command_line(args)
+    return if @help_requested
+
+    cmd = 'rpm -q simp'
+    begin
+      `#{cmd}`.split(/\n/).last.match(/([0-9]+\.[0-9]+\.?[0-9]*)/)[1]
+    rescue
+      #TODO Send this message to stderr instead of stdout?
+      msg = 'Version unknown:'
+      msg += "  Cannot find SIMP OS installation via `#{cmd}`!"
+      puts msg
+    end
+  end
+  def parse_command_line(args)
+    if args.include?('-h') or args.include?('--help')
+      help
+      @help_requested = true
+    elsif args.size > 0
+      raise OptionParser::ParseError.new("Unsupported option: #{args.first}")
+    end
+  end
+
+  def parse_command_line(args)
+    if args.include?('-h') or args.include?('--help')
+      puts help
+      @help_requested = true
+    elsif args.size > 0
+      raise OptionParser::ParseError.new("Unsupported option: #{args.first}")
+    end
+  end
+
+end

--- a/lib/simp/cli/commands/version.rb
+++ b/lib/simp/cli/commands/version.rb
@@ -7,7 +7,7 @@ class Simp::Cli::Commands::Version < Simp::Cli::Commands::Command
   end
 
   def help
-    puts "\n#{description}\n\nUsage:  simp version\n"
+    puts "\n#{description}\n\nUsage:  simp version\n\n"
   end
 
   def run(args)
@@ -26,7 +26,7 @@ class Simp::Cli::Commands::Version < Simp::Cli::Commands::Command
 
   def parse_command_line(args)
     if args.include?('-h') or args.include?('--help')
-      puts help
+      help
       @help_requested = true
     elsif args.size > 0
       raise OptionParser::ParseError.new("Unsupported option: #{args.first}")

--- a/spec/bin/simp_spec.rb
+++ b/spec/bin/simp_spec.rb
@@ -94,7 +94,7 @@ describe 'simp executable' do
       warn("=== stderr: #{results[:stderr]}") unless (results[:stderr]).empty?
       warn("=== stdout: #{results[:stdout]}") unless (results[:stdout]).empty?
       expect(results[:exitstatus]).to eq 0
-      expect(results[:stdout]).to match(/Usage: simp \[command\]/)
+      expect(results[:stdout]).to match(/SIMP Command Line Interface/)
       expect(results[:stderr]).to be_empty
     end
 

--- a/spec/lib/simp/cli/commands/doc_spec.rb
+++ b/spec/lib/simp/cli/commands/doc_spec.rb
@@ -1,0 +1,34 @@
+require 'simp/cli/commands/doc'
+
+describe 'Simp::Cli::Command::Doc' do
+  let(:files_dir) { File.join(__dir__, 'files') }
+
+  before(:each) do
+    @doc = Simp::Cli::Commands::Doc.new
+  end
+
+  context '#run' do
+    context 'help' do
+      it 'prints help message' do
+        usage = <<-EOM
+
+=== The SIMP Doc Tool ===
+Show SIMP documentation in elinks, a text-based web browser
+
+Usage:  simp doc
+
+EOM
+        expect{ @doc.run(['-h']) }.to output(usage).to_stdout
+        expect{ @doc.run(['--help']) }.to output(usage).to_stdout
+      end
+    end
+
+    context 'invalid options' do
+      it 'fails if any other option specified' do
+        expect{ @doc.run(['-x']) }.to raise_error(/Unsupported option: \-x/)
+      end
+
+    end
+  end
+
+end

--- a/spec/lib/simp/cli/commands/version_spec.rb
+++ b/spec/lib/simp/cli/commands/version_spec.rb
@@ -1,0 +1,33 @@
+require 'simp/cli/commands/version'
+
+describe 'Simp::Cli::Command::Version' do
+  let(:files_dir) { File.join(__dir__, 'files') }
+
+  before(:each) do
+    @version = Simp::Cli::Commands:: Version.new
+  end
+
+  context '#run' do
+    context 'help' do
+      it 'prints help message' do
+        usage = <<-EOM
+
+Display the current version of SIMP.
+
+Usage:  simp version
+
+EOM
+        expect{ @version.run(['-h']) }.to output(usage).to_stdout
+        expect{ @version.run(['--help']) }.to output(usage).to_stdout
+      end
+    end
+
+    context 'invalid options' do
+      it 'fails if any other option specified' do
+        expect{ @version.run(['-x']) }.to raise_error(/Unsupported option: \-x/)
+      end
+
+    end
+  end
+
+end

--- a/spec/lib/simp/cli/commands/version_spec.rb
+++ b/spec/lib/simp/cli/commands/version_spec.rb
@@ -28,6 +28,20 @@ EOM
       end
 
     end
+
+    context 'SIMP rpm is installed' do
+      it 'should print simp RPM version' do
+        allow(@version).to receive(:`).with('rpm -q simp').and_return('6.4.0-0.el7.noarch')
+        expect { @version.run([]) }.to output("6.4.0\n").to_stdout
+      end
+    end
+
+    context 'SIMP rpm is not installed' do
+      it 'should fail' do
+        allow(@version).to receive(:`).with('rpm -q simp').and_return('package simp is not installed')
+        expect { @version.run([]) }.to raise_error(Simp::Cli::ProcessingError, /Version unknown/)
+      end
+    end
   end
 
 end

--- a/spec/lib/simp/cli_spec.rb
+++ b/spec/lib/simp/cli_spec.rb
@@ -13,17 +13,25 @@ describe 'Simp::Cli' do
   describe 'Simp::Cli.start' do
     describe 'help' do
       before :all do
-        @usage = "Usage: simp [command]\n" +
-                 "\n" +
-                 "  Commands\n" +
-                 "    - bootstrap\n" +
-                 "    - config\n" +
-                 "    - doc\n" +
-                 "    - environment\n" +
-                 "    - passgen\n" +
-                 "    - puppetfile\n" +
-                 "    - version\n" +
-                 "    - help [command]\n\n"
+        @usage = <<EOM
+SIMP Command Line Interface
+
+Usage:
+
+ simp -h
+ simp COMMAND -h
+ simp COMMAND [command options]
+
+COMMANDS
+  bootstrap     Bootstrap initial SIMP server
+  config        Prepare SIMP server for bootstrapping
+  doc           Show SIMP documentation in elinks
+  environment   Utility to manage and coordinate SIMP omni-environments
+  passgen       Utility for managing 'passgen' passwords
+  puppetfile    Helper utility to maintain local SIMP Puppetfiles
+  version       Display the current version of SIMP.
+
+EOM
       end
 
       it 'outputs general usage when no command specified' do
@@ -36,33 +44,37 @@ describe 'Simp::Cli' do
         expect( @result ).to be @success_status
       end
 
+      it 'outputs general usage when -h specified' do
+        expect{ @result = Simp::Cli.start(['-h']) }.to output(@usage).to_stdout
+        expect( @result ).to be @success_status
+      end
+
+      it 'outputs general usage when --help specified' do
+        expect{ @result = Simp::Cli.start(['--help']) }.to output(@usage).to_stdout
+        expect( @result ).to be @success_status
+      end
+
       it 'outputs general usage when invalid command specified' do
         expect{ @result = Simp::Cli.start(['oops']) }.to output(/oops is not a recognized command/).to_stderr
         expect( @result ).to be @failure_status
       end
 
       it 'outputs bootstrap usage when bootstrap help specified' do
-        expect{ @result = Simp::Cli.start(['help','bootstrap']) }.to output(/=== The SIMP Bootstrap Tool ===/m).to_stdout
-        expect( @result ).to be @success_status
         expect{ @result = Simp::Cli.start(['bootstrap', '-h']) }.to output(/=== The SIMP Bootstrap Tool ===/m).to_stdout
         expect( @result ).to be @success_status
       end
 
       it 'outputs config usage when config help specified' do
-        expect{ @result = Simp::Cli.start(['help','config']) }.to output(/=== The SIMP Configuration Tool ===/m).to_stdout
-        expect( @result ).to be @success_status
         expect{ @result = Simp::Cli.start(['config', '-h']) }.to output(/=== The SIMP Configuration Tool ===/m).to_stdout
         expect( @result ).to be @success_status
       end
 
       it 'outputs doc usage when doc help specified' do
-        expect{ @result = Simp::Cli.start(['help','doc']) }.to output(/=== The SIMP Doc Tool ===/m).to_stdout
+        expect{ @result = Simp::Cli.start(['doc', '-h']) }.to output(/=== The SIMP Doc Tool ===/m).to_stdout
         expect( @result ).to be @success_status
       end
 
       it 'outputs passgen usage when passgen help specified' do
-        expect{ @result = Simp::Cli.start(['help','passgen']) }.to output(/=== The SIMP Passgen Tool ===/m).to_stdout
-        expect( @result ).to be @success_status
         expect{ @result = Simp::Cli.start(['passgen', '-h']) }.to output(/=== The SIMP Passgen Tool ===/m).to_stdout
         expect( @result ).to be @success_status
       end


### PR DESCRIPTION
- Standardized top level help
  - Replaced 'simp help command', with 'simp -h', because the
    help command mechanism was not supported by subcommands
    which made the help API confusing
  - Created version command and added -h option to it
  - Added -h option to doc command
- Added brief descriptions to top level help