### PR TITLE
(SIMP-6662) simp env new behavior matches `--help`

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -129,6 +129,14 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Tue Jun 11 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0
+  - `simp environment new` changes:
+    - Behaviors match `--help` documentation:
+      - `--skeleton` implies `--puppetfile`
+      - `--puppetfile`:
+        - generates `Puppetfile.simp` from local RPM/git repos
+        - generates a skeleton `Puppetfile` (if needed)
+    - Fails before acting if any component environment cannot be created
 * Fri Jun 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0
 - 'simp' change:
   - Standardized help mechanism to be -h at all levels

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -130,48 +130,28 @@ EOM
 
 %changelog
 * Tue Jun 11 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0
-  - `simp environment new` changes:
-    - Behaviors match `--help` documentation:
-      - `--skeleton` implies `--puppetfile`
-      - `--puppetfile`:
-        - generates `Puppetfile.simp` from local RPM/git repos
-        - generates a skeleton `Puppetfile` (if needed)
-    - Fails before acting if any component environment cannot be created
+- Added 'simp environment' command
+- Added `simp environment new` subcommand
+- Added `simp environment fix` subcommand
+- Added `simp puppetfile generate` command
+  - `simp puppetfile` command
+  - `simp puppetfile generate` sub-command
+- Fixed various annoyances that prevented local smoke tests with `bin/simp`
+  - Avoid using AIO Puppet with `USE_AIO_PUPPET=no`
+  - Load all `simp` commands without `simp config` failing in non-puppetserver
+    environments (`simp config` still fails as expected)
+- Moved logger to `Simp::Cli::Logging`
+- Fixed gem dependency-related warning when `simp` is run on real OSes
+  - Updated dependency constraints in gemspec
+  - Removed unnecessary ENV wrapper from gemspec
+  - Documented changes in README.md
+
 * Fri Jun 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0
 - 'simp' change:
   - Standardized help mechanism to be -h at all levels
     (main, command, subcommand)
   - Added descriptions to top level help command list
-- 'simp puppetfile generate' changes:
-  - Added '--local-modules ENV' option, which will add each local
-    (unmanaged) module found in a Puppet environment to the
-    generated skeleton Puppetfile as `:local => true`.  This option is
-    key for sites that have unmanaged, locally-written modules in an
-    environment. Without the local references, those modules will be
-    purged by r10K/Code Manager, when that environment's generated
-    Puppetfile is deployed.
-  - Changed the ':git' references for the local SIMP module repos
-    in the generated Puppetfiles from file paths to file URLs.
-  - Sorted modules listed in generated Puppetfile by their
-    names from their respective metadata.json files.
-  - Changed the error handling of problematic modules found in
-    /usr/share/simp/modules. The generator now warns the user
-    and skips the module in lieu of aborting.
-  - Added tag validation for each SIMP module installed in
-    /usr/share/simp/modules.  The generator now verifies that the
-    tag for each module exists in its local Git repository, before
-    creating a Puppetfile entry for the module.
-  - Improved error handling.  Backtraces on errors for which the
-    error message is sufficient are now suppressed.
 - Added 'rsync' and 'git' to the RPM requires list.
-
-* Fri Apr 26 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0
-- New features:
-  - Added 'simp environment' command
-  - Added `simp environment new` subcommand
-  - Added `simp environment fix` subcommand
-
-* Fri Apr 26 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 5.0.0
 - 'simp' change:
   - Fixed bug in which the wrong Facter environment variable was set
 - 'simp config' changes:
@@ -215,8 +195,9 @@ EOM
     fails validation.
   - Added simp-cli version to the answers file as a YAML entry.
 - 'simp bootstrap' changes:
-    (with 'production' links), if they do not exist.  Instead, checks
-    for the existence of SIMP Puppet and secondary 'production'
+    No longer checks for the 'simp' Puppet and secondary environments (with
+    their corresponding 'production' links) and fails if they do not exist.
+    Instead, checks for the existence of SIMP Puppet and secondary 'production'
     environments and fails if both are not present.
   - Checks validity of manifests in the 'production' environment,
     not 'simp' environment, as the link that made them
@@ -231,33 +212,15 @@ EOM
 - Added message to bootstrap.rb indicating that puppetserver has been
   reconfigured to listen on a specific port. This message will be
   displayed if the port is changed to 8140, or if it remains on 8150.
-
-* Wed Mar 20 2019 Jim Anderson <thesemicolons@protonmail.com> - 5.0.0
 - Fixed bug in which 'simp config' failed to find the template
   SIMP server host YAML file, puppet.your.domain.yaml, from
-  /usr/share simp/enviornments/simp.  This bug caused subsequent
+  /usr/share simp/environments/simp.  This bug caused subsequent
   'simp config' runs to fail, when the SIMP server hostname had
   changed from the hostname used in the first 'simp config' run.
 
 * Mon Mar 18 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0
-- Ensure that an FQDN is used when running `simp config`
-- Ensure that an FQDN is set when running `simp bootstrap`
-
-* Mon Mar 11 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0
-- Added `simp puppetfile generate` command
-  - `simp puppetfile` command
-  - `simp puppetfile generate` sub-command
-- Fixed various annoyances that prevented local smoke tests with `bin/simp`
-  - Avoid using AIO Puppet with `USE_AIO_PUPPET=no`
-  - Load all `simp` commands without `simp config` failing in non-puppetserver
-    environments (`simp config` still fails as expected)
-- Moved logger to `Simp::Cli::Logging`
-- Fixed gem depenency-related warning when `simp` is run on real OSes
-  - Updated dependency constraints in gemspec
-  - Removed unnecessary ENV wrapper from gemspec
-  - Documented changes in README.md
-
-* Thu Feb 07 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0
+- Ensure that a FQDN is used when running `simp config`
+- Ensure that a FQDN is set when running `simp bootstrap`
 - Fixed a bug where the web-routes.conf file was not being overwritten with a
   pristine copy. This meant that multiple calls to `simp bootstrap` would fail
   due to leftover CA entries in the file. The error provided is not clear and

--- a/lib/simp/cli/command_logger.rb
+++ b/lib/simp/cli/command_logger.rb
@@ -69,6 +69,12 @@ module Simp::Cli::CommandLogger
             'recorded in the log file regardless.') do
       options[:verbose] = -1
     end
+
+    opt_parser.on('--console-only',
+                  'Suppress logging to file.') do
+      options[:log_file] = :none
+    end
+
   end
 
   # Set up the global logger
@@ -90,7 +96,8 @@ module Simp::Cli::CommandLogger
   #   :log_basename = Basename of the log file to be opened.  Used to
   #                   generate the name of the log file, when :log_file
   #                   is not specified.
-  #   :log_file     = Fully qualified path to the log file
+  #   :log_file     = Fully qualified path to the log file or :none,
+  #                   if file logging has been disabled
   #   :start_time   = Time the command processing started
   #   :verbose      = Verbosity of console messages.  Will be set to
   #                   NOTICE and above, if missing.
@@ -114,8 +121,11 @@ module Simp::Cli::CommandLogger
       log_file = "#{options[:log_basename]}.#{timestamp}"
       options[:log_file] = File.join(Simp::Cli::SIMP_CLI_HOME, log_file)
     end
-    FileUtils.mkdir_p(File.dirname(options[:log_file]))
-    logger.open_logfile(options[:log_file])
+
+    unless (options[:log_file] == :none)
+      FileUtils.mkdir_p(File.dirname(options[:log_file]))
+      logger.open_logfile(options[:log_file])
+    end
 
     options[:verbose] = 0 unless options[:verbose]
     case options[:verbose]

--- a/lib/simp/cli/commands/environment/new.rb
+++ b/lib/simp/cli/commands/environment/new.rb
@@ -14,10 +14,11 @@ class Simp::Cli::Commands::Environment::New < Simp::Cli::Commands::Command
   include Simp::Cli::CommandLogger
 
   TYPES=[:puppet, :secondary, :writable]
+  STRATEGY_ARGS=['--skeleton', '--copy', '--link']
 
   # @return [String] description of command
   def self.description
-    'Create a new SIMP "Extra" (default) or "omni" environment'
+    'Create a new SIMP "Omni" environment (or a subset)'
   end
 
   # Run the command's `--help` strategy
@@ -25,11 +26,21 @@ class Simp::Cli::Commands::Environment::New < Simp::Cli::Commands::Command
     parse_command_line(['--help'])
   end
 
+  def fail_on_multiple_strategies(args)
+    if args.count{ |x| STRATEGY_ARGS.include?(x) } > 1
+      fail(
+        Simp::Cli::ProcessingError,
+        "ERROR: Cannot specify more than one of: #{STRATEGY_ARGS.join(', ')}"
+      )
+    end
+  end
+
   # Parse command-line options for this simp command
   # @param args [Array<String>] ARGV-style args array
   def parse_command_line(args)
     # TODO: simp cli should read a config file that can override these defaults
-    # these options (preferrable mimicking cmd-line args)
+    # these options (preferrably mimicking cmd-line args)
+    default_options = Simp::Cli::Utils.default_simp_env_config
     options = Simp::Cli::Utils.default_simp_env_config
     options[:action] = :create
     options[:start_time] = Time.now
@@ -58,67 +69,81 @@ class Simp::Cli::Commands::Environment::New < Simp::Cli::Commands::Command
 
         By default, this command will:
 
-          * create a new environment (–-skeleton)
-          * raise an error if an environment directory already exists
+          * create a new SIMP Omni environment (–-skeleton)
 
-        It can create a complete SIMP omni-environment with --puppet-env
+          * raise an error if an environment directory already exists
 
         Examples:
 
-             # Create a skeleton new development environment
+             # Generate a new Omni environment directory from skeleton (default)
+             #
+             #   * Creates skeleton Puppet and Secondary environment directories
+             #   * Generates new Puppetfile and Puppetfile.simp
+             #     - see: `simp puppetfile generate --help`
+             #   * Runs `r10k puppetfile install` in `local_prod` Puppet env dir
+             #
              simp environment new development
 
              # Link staging's Secondary and Writable env dirs to production
              simp environment new staging --link production
 
              # Create a separate copy of production (will diverge over time)
-             simp environment new newprod --copy production
+             simp environment new new_prod --copy production
 
-             # Create new omni environment
-             simp environment new local_prod --puppetfile
+             # Create + deploy new `local_prod` Omni environment from skeleton
+             simp environment new local_prod --no-puppetenv
 
         Options:
 
       HELP_MSG
 
       opts.on('--skeleton',
-              '(default) Generate environments from skeleton templates.',
-              'Implies --puppetfile') do
-                TYPES.each do |type|
-                  options[:types][type][:strategy]    = :skeleton
-                end
-                # NOTE: The default --no-puppetfile will always set this to
-                #       false in a later opts.on block, so this logic must be
-                #       handled there.
-                # options[:types][:puppet][:puppetfile_generate] = true
-              end
+               '(default) Generate environments from skeleton templates.',
+               'Implies `--puppetfile` when `--puppet-env` is enabled.') do
+         say "=== do --skeleton".yellow if options[:debug]
+         TYPES.each do |type|
+           options[:types][type][:strategy]    = :skeleton
+         end
+         unless(args.include?('--no-puppet-env'))
+           unless(args.include?('--no-puppetfile'))
+             say "=== do --skeleton: add --puppetfile".cyan if options[:debug]
+             args << '--puppetfile'
+           end
+         end
+      end
 
       opts.on('--copy ENVIRONMENT', Simp::Cli::Utils::REGEXP_PUPPET_ENV_NAME,
               'Copy assets from ENVIRONMENT') do |src_env|
-                TYPES.each do |type|
-                  options[:types][type][:strategy] = :copy
-                  options[:types][type][:src_env]  = src_env
-                end
-              end
+        say "=== do --copy #{src_env}".yellow if options[:debug]
+        TYPES.each do |type|
+          options[:types][type][:strategy] = :copy
+          options[:types][type][:src_env]  = src_env
+        end
+      end
 
       opts.on('--link ENVIRONMENT', Simp::Cli::Utils::REGEXP_PUPPET_ENV_NAME,
               'Symlink Secondary and Writable environment directories',
               'to ENVIRONMENT.  If --puppet-env is set, the Puppet',
               'environment will --copy.') do |src_env|
-                TYPES.each do |type|
-                  options[:types][type][:strategy] = :link
-                  options[:types][type][:src_env]  = src_env
-                end
-                options[:types][:puppet][:strategy] = :copy
-              end
+        say "=== do --link #{src_env}".yellow if options[:debug]
+        TYPES.each do |type|
+          options[:types][type][:strategy] = :link
+          options[:types][type][:src_env]  = src_env
+        end
+        options[:types][:puppet][:strategy] = :copy
+      end
 
       opts.on('--[no-]puppetfile',
               'Generate Puppetfiles in Puppet env directory',
               '  * `Puppetfile` will only be created if missing',
               '  * `Puppetfile.simp` will be generated from RPM/',
               '  * Implies `--puppet-env`') do |v|
-        options[:types][:puppet][:puppetfile_generate] = (v || options[:types][type][:strategy] == :skeleton)
-        options[:types][:puppet][:enabled] = true if (options[:types][:puppet][:puppetfile_generate] = v)
+        say "=== do --puppetfile = #{v}".yellow if options[:debug]
+        options[:types][:puppet][:puppetfile_generate] = v
+        unless(args.include?('--no-puppet-env'))
+          say "===    --puppetfile: add --puppet-env".cyan if options[:debug]
+          args << '--puppet-env' if v
+        end
       end
 
       opts.on('--[no-]puppetfile-install',
@@ -126,12 +151,25 @@ class Simp::Cli::Commands::Environment::New < Simp::Cli::Commands::Command
               'directory after creating it',
               '  * Implies `--puppet-env`',
               '  * Does NOT imply `--puppetfile`') do |v|
-        options[:types][:puppet][:enabled] = true if (options[:types][:puppet][:puppetfile_install] = v)
+        say "=== do --puppetfile-install = #{v}".yellow if options[:debug]
+        options[:types][:puppet][:puppetfile_install] = v
+        unless(args.include?('--no-puppet-env'))
+          if v
+            say "===    --puppetfile-install: add --puppet-env".cyan if options[:debug]
+            args << '--puppet-env'
+          end
+        end
       end
 
       opts.on('--[no-]puppet-env',
               'Includes Puppet environment when `--puppet-env`',
-              '(default: --no-puppet-env)') { |v| options[:types][:puppet][:enabled] = v }
+              '(defaults:',
+              '  when `--skeleton` (default): --puppet-env',
+              '  when `--copy` or `--link`:   --no-puppet-env',
+              ')') do |v|
+                say "=== do --puppet-env = #{v}".yellow if options[:debug]
+                options[:types][:puppet][:enabled] = v
+              end
 
       opts.on('--[no-]secondary-env',
               'Includes Secondary environment when `--secondary-env`',
@@ -150,22 +188,32 @@ class Simp::Cli::Commands::Environment::New < Simp::Cli::Commands::Command
         @help_requested = true
       end
     end
-    opt_parser.parse!(args)
-    options
+
+    orig_args = args.dup
+    # implications
+    unless STRATEGY_ARGS.any?{ |x| args.include?(x) }
+      say "=== default: add --skeleton".cyan if options[:debug]
+      args << '--skeleton'
+    end
+    fail_on_multiple_strategies(args)
+    remaining_args = opt_parser.parse(args)
+    if options[:debug]
+      say "original args: '#{orig_args}'".cyan
+      say "final args: '#{args}'".bold
+    end
+
+    [options, remaining_args]
   end
 
   # Run command logic
   # @param args [Array<String>] ARGV-style args array
   def run(args)
-    options = parse_command_line(args)
+    options, remaining_args = parse_command_line(args)
+
     return if @help_requested
 
-    action = options.delete(:action)
-
-    fail(Simp::Cli::ProcessingError, "ERROR: 'ENVIRONMENT' is required.") if args.empty?
-
-    env = args.shift
-
+    fail(Simp::Cli::ProcessingError, "ERROR: 'ENVIRONMENT' is required.") if remaining_args.empty?
+    env = remaining_args.shift
     unless Simp::Cli::Utils::REGEXP_PUPPET_ENV_NAME.match?(env)
       fail(
         Simp::Cli::ProcessingError,

--- a/lib/simp/cli/commands/environment/new.rb
+++ b/lib/simp/cli/commands/environment/new.rb
@@ -228,6 +228,7 @@ class Simp::Cli::Commands::Environment::New < Simp::Cli::Commands::Command
     end
     logger.debug("Environment creation options:\n#{options.to_yaml}\n")
 
+    action = options.delete(:action)
     omni_controller = Simp::Cli::Environment::OmniEnvController.new(options, env)
     omni_controller.send(action)
 

--- a/lib/simp/cli/commands/environment/new.rb
+++ b/lib/simp/cli/commands/environment/new.rb
@@ -87,7 +87,10 @@ class Simp::Cli::Commands::Environment::New < Simp::Cli::Commands::Command
                 TYPES.each do |type|
                   options[:types][type][:strategy]    = :skeleton
                 end
-                options[:types][:puppet][:puppetfile_generate] = true
+                # NOTE: The default --no-puppetfile will always set this to
+                #       false in a later opts.on block, so this logic must be
+                #       handled there.
+                # options[:types][:puppet][:puppetfile_generate] = true
               end
 
       opts.on('--copy ENVIRONMENT', Simp::Cli::Utils::REGEXP_PUPPET_ENV_NAME,
@@ -114,6 +117,7 @@ class Simp::Cli::Commands::Environment::New < Simp::Cli::Commands::Command
               '  * `Puppetfile` will only be created if missing',
               '  * `Puppetfile.simp` will be generated from RPM/',
               '  * Implies `--puppet-env`') do |v|
+        options[:types][:puppet][:puppetfile_generate] = (v || options[:types][type][:strategy] == :skeleton)
         options[:types][:puppet][:enabled] = true if (options[:types][:puppet][:puppetfile_generate] = v)
       end
 

--- a/lib/simp/cli/config/items/action/configure_network_action.rb
+++ b/lib/simp/cli/config/items/action/configure_network_action.rb
@@ -23,7 +23,6 @@ module Simp::Cli::Config
 
     def apply
       @applied_status = :failed
-      ci  = {}
       cmd = nil
 
       dhcp      = get_item( 'cli::network::dhcp' ).value

--- a/lib/simp/cli/config/items/action_item.rb
+++ b/lib/simp/cli/config/items/action_item.rb
@@ -98,7 +98,7 @@ module Simp::Cli::Config
 
       @category          = :other        # category which can be used to group actions when applied
                                          # see SORTED_CATEGORIES above for recognized categories
- 
+
       # TODO Should just be able to use module paths from @puppet_env_info,
       # because we have ensured the SIMP environment is place before attempting
       # the 'simp config' questionnaire. The only reason for using the SIMP

--- a/lib/simp/cli/environment/dir_env.rb
+++ b/lib/simp/cli/environment/dir_env.rb
@@ -99,5 +99,15 @@ module Simp::Cli::Environment
         warn("WARNING: Source environment directory '#{src_env_dir}' does not exist to link; skipping.".yellow)
       end
     end
+
+    def fail_unless_createable
+      # Safety feature: Don't clobber an environment directory that already has content
+      unless Dir.glob(File.join(@directory_path, '*')).empty?
+        fail(
+          Simp::Cli::ProcessingError,
+          "ERROR: A directory with content already exists at '#{@directory_path}'"
+        )
+      end
+    end
   end
 end

--- a/lib/simp/cli/environment/dir_env.rb
+++ b/lib/simp/cli/environment/dir_env.rb
@@ -29,7 +29,7 @@ module Simp::Cli::Environment
           execute("restorecon -R -F -p #{path}")
         end
       else
-        info("SELinux is disabled; skipping context fixfiles for '#{paths}'".yellow)
+        info("SELinux is disabled; skipping context restorecon for '#{paths}'".yellow)
       end
     end
 
@@ -60,8 +60,8 @@ module Simp::Cli::Environment
       rsync = Facter::Core::Execution.which('rsync')
       fail("Error: Could not find 'rsync' command!") unless rsync
 
-      cmd = "#{rsync} -a '#{src_dir}'/ '#{dest_dir}'/ 2>&1"
-      cmd = %(sg - #{group} -c '#{rsync} -a --no-g "#{src_dir}/" "#{dest_dir}/" 2>&1') if ENV.fetch('USER') == 'root' && group
+      cmd = "#{rsync} -a '#{src_dir}'/ '#{dest_dir}'/"
+      cmd = %(sg - #{group} -c '#{rsync} -a --no-g "#{src_dir}/" "#{dest_dir}/"') if ENV.fetch('USER') == 'root' && group
 
       debug("Copying '#{src_dir}' files into '#{dest_dir}'")
       success = execute(cmd)

--- a/lib/simp/cli/environment/dir_env.rb
+++ b/lib/simp/cli/environment/dir_env.rb
@@ -29,7 +29,7 @@ module Simp::Cli::Environment
           execute("restorecon -R -F -p #{path}")
         end
       else
-        info("SELinux is disabled; skipping context fixfiles for '#{path}'".yellow)
+        info("SELinux is disabled; skipping context fixfiles for '#{paths}'".yellow)
       end
     end
 

--- a/lib/simp/cli/environment/env.rb
+++ b/lib/simp/cli/environment/env.rb
@@ -58,8 +58,8 @@ module Simp::Cli::Environment
     # Execute a command in a child process, log failure and return
     # a hash with the command status, stdout and stderr.
     #
-    # +command+:  Command to be executed
-    # +ignore_failure+:  Whether to ignore failures.  When true and
+    # @param [String] command  Command to be executed
+    # @param [Boolean] ignore_failure  Whether to ignore failures.  When true and
     #   and the command fails, does not log the failure and returns
     #   a hash with :status = true
     #
@@ -70,8 +70,8 @@ module Simp::Cli::Environment
     # Execute a command in a child process, log failure and return
     # whether command succeeded.
     #
-    # +command+:  Command to be executed
-    # +ignore_failure+:  Whether to ignore failures.  When true and
+    # @param [String] command  Command to be executed
+    # @param [Boolean] ignore_failure  Whether to ignore failures.  When true and
     #   the command fails, does not log the failure and returns true.
     def execute(command, ignore_failure = false)
       return Simp::Cli::ExecUtils::execute(command, ignore_failure, logger)
@@ -105,5 +105,8 @@ module Simp::Cli::Environment
       logger.fatal(*args)
     end
 
+    def fail_unless_createable
+      fail NotImplementedError, "Implement .#{__method__} in a subclass"
+    end
   end
 end

--- a/lib/simp/cli/environment/env.rb
+++ b/lib/simp/cli/environment/env.rb
@@ -13,10 +13,10 @@ module Simp::Cli::Environment
 
     include Simp::Cli::Logging
 
-    # +type+: symbol indicating type of environment (e.g., :puppet, :secondary...);
-    #         used in log messages
-    # +name+: environment name
-    # +opts+: options Hash
+    # @param [Symbol] type  symbol indicating type of environment (e.g.,
+    #   :puppet,  secondary...); used in log messages
+    # @param [String] name  environment name
+    # @param [Hash]   opts  options Hash
     def initialize(type, name, opts)
       unless Simp::Cli::Utils::REGEXP_PUPPET_ENV_NAME.match?(name)
         fail(ArgumentError, "ERROR: Illegal environment name: '#{name}'" \

--- a/lib/simp/cli/environment/omni_env_controller.rb
+++ b/lib/simp/cli/environment/omni_env_controller.rb
@@ -53,6 +53,7 @@ module Simp::Cli::Environment
         ].join("\n")
       end
     end
+
     # Create a new environment for each environment type
     def create
       # ensure environments are createable before proceeding
@@ -63,7 +64,6 @@ module Simp::Cli::Environment
         env_obj.create
       end
 
-      each_environment('create') { |_t, env_obj| env_obj.create }
       fix  # ensure environments are correct after creating them
     end
 

--- a/lib/simp/cli/environment/secondary_dir_env.rb
+++ b/lib/simp/cli/environment/secondary_dir_env.rb
@@ -45,16 +45,7 @@ module Simp::Cli::Environment
     #
     # @see https://simp-project.atlassian.net/wiki/spaces/SD/pages/edit/757497857#simp_cli_environment_changes
     def create
-      <<-TODO.gsub(%r{^ {6}}, '')
-
-      TODO
-
-      if File.exist? @directory_path
-        fail(
-          Simp::Cli::ProcessingError,
-          "ERROR: Secondary environment directory already exists at '#{@directory_path}'\n"
-        )
-      end
+      fail_unless_createable
 
       case @opts[:strategy]
       when :skeleton

--- a/lib/simp/cli/environment/secondary_dir_env.rb
+++ b/lib/simp/cli/environment/secondary_dir_env.rb
@@ -160,7 +160,6 @@ module Simp::Cli::Environment
         os_info = dir.split('/')[-5..-3]
         dst_dirname = os_info.map(&:downcase).join('-')
         dst_path = File.join(@tftpboot_dest_path, dst_dirname)
-        FileUtils.mkdir_p File.basename(@tftpboot_src_path)
         copy_skeleton_files(dir, dst_path, 'nobody')
 
         # create major OS version link

--- a/lib/simp/cli/environment/writable_dir_env.rb
+++ b/lib/simp/cli/environment/writable_dir_env.rb
@@ -14,13 +14,7 @@ module Simp::Cli::Environment
 
     # Create a new environment
     def create
-      # Safety feature: Don't clobber a Puppet environment directory that already has content
-      unless Dir.glob(File.join(@directory_path, '*')).empty?
-        fail(
-          Simp::Cli::ProcessingError,
-          "ERROR: A Writable environment directory with content already exists at '#{@directory_path}'"
-        )
-      end
+      fail_unless_createable
 
       case @opts[:strategy]
 

--- a/spec/lib/simp/cli/commands/environment/fix_spec.rb
+++ b/spec/lib/simp/cli/commands/environment/fix_spec.rb
@@ -27,18 +27,16 @@ describe Simp::Cli::Commands::Environment::Fix do
       end
     end
 
-    context 'with argument `--skeleton`' do
+    context 'with default options' do
       let(:omni_spy) { instance_double('OmniEnvController') }
 
       before(:each) do
         allow(Simp::Cli::Environment::OmniEnvController).to receive(:new).and_return(omni_spy)
         allow(omni_spy).to receive(:fix)
-        allow($stdout).to receive(:write)
-        allow($stderr).to receive(:write)
       end
 
       it 'runs OmniEnvController#fix' do
-        described_class.new.run(['foo'])
+        described_class.new.run(['foo', '--console-only'])
 
         expect(Simp::Cli::Environment::OmniEnvController).to have_received(:new).with(
           hash_including(
@@ -52,7 +50,7 @@ describe Simp::Cli::Commands::Environment::Fix do
       end
 
       it 'runs OmniEnvController#fix' do
-        described_class.new.run(['foo'])
+        described_class.new.run(['foo', '--console-only'])
         expect(omni_spy).to have_received(:fix).once
       end
     end

--- a/spec/lib/simp/cli/commands/environment/fix_spec.rb
+++ b/spec/lib/simp/cli/commands/environment/fix_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 require 'simp/cli/commands/environment'
-require 'simp/cli/commands/environment/new'
+require 'simp/cli/commands/environment/fix'
 require 'simp/cli/environment/omni_env_controller'
 require 'spec_helper'
 
-describe Simp::Cli::Commands::Environment::New do
+describe Simp::Cli::Commands::Environment::Fix do
   describe '#run' do
     context 'with default arguments' do
       subject(:run) { proc { described_class.new.run([]) } }
@@ -32,12 +32,12 @@ describe Simp::Cli::Commands::Environment::New do
 
       before(:each) do
         allow(Simp::Cli::Environment::OmniEnvController).to receive(:new).and_return(omni_spy)
-        allow(omni_spy).to receive(:create)
+        allow(omni_spy).to receive(:fix)
         allow($stdout).to receive(:write)
         allow($stderr).to receive(:write)
       end
 
-      it 'runs OmniEnvController#create' do
+      it 'runs OmniEnvController#fix' do
         described_class.new.run(['foo'])
 
         expect(Simp::Cli::Environment::OmniEnvController).to have_received(:new).with(
@@ -51,9 +51,9 @@ describe Simp::Cli::Commands::Environment::New do
         )
       end
 
-      it 'runs OmniEnvController#create' do
+      it 'runs OmniEnvController#fix' do
         described_class.new.run(['foo'])
-        expect(omni_spy).to have_received(:create).once
+        expect(omni_spy).to have_received(:fix).once
       end
     end
   end

--- a/spec/lib/simp/cli/commands/environment/new_spec.rb
+++ b/spec/lib/simp/cli/commands/environment/new_spec.rb
@@ -11,16 +11,12 @@ describe Simp::Cli::Commands::Environment::New do
       subject(:run) { proc { described_class.new.run([]) } }
 
       it 'requires an ENVIRONMENT argument' do
-        allow($stdout).to receive(:write)
-        allow($stderr).to receive(:write)
         expect { run.call }.to raise_error(Simp::Cli::ProcessingError, %r{ENVIRONMENT.*is required})
       end
     end
 
     context 'with an invalid environment' do
       it 'requires a valid ENVIRONMENT argument' do
-        allow($stdout).to receive(:write)
-        allow($stderr).to receive(:write)
         expect { described_class.new.run(['.40ris']) }.to raise_error(
           Simp::Cli::ProcessingError, %r{is not an acceptable environment name}
         )
@@ -28,32 +24,108 @@ describe Simp::Cli::Commands::Environment::New do
     end
 
     # rubocop:disable RSpec/InstanceVariable
-    context 'with default strategy :skeleton`' do
+    shared_examples 'a `simp environment new` command' do
       before :each do
-        allow($stdout).to receive(:write)
-        allow($stderr).to receive(:write)
         @spy = instance_double('OmniEnvController')
         allow(Simp::Cli::Environment::OmniEnvController).to receive(:new).and_return(@spy)
         allow(@spy).to receive(:create)
       end
-      it 'instantiates OmniEnvController' do
-        described_class.new.run(['foo'])
 
+      it 'instantiates OmniEnvController with expected options' do
+        simp_env_new.call
         expect(Simp::Cli::Environment::OmniEnvController).to have_received(:new).with(
-          hash_including(
-            types: hash_including(
-              puppet: hash_including(backend: :directory, strategy: :skeleton),
-              secondary: hash_including(backend: :directory, strategy: :skeleton),
-              writable: hash_including(backend: :directory, strategy: :skeleton)
-            )
-          ), 'foo'
+          expected_hash, expected_environment
         )
       end
-      it 'runs OmniEnvController.create' do
-        described_class.new.run(['foo'])
+
+      it 'calls OmniEnvController.create' do
+        simp_env_new.call
         expect(@spy).to have_received(:create)
       end
     end
     # rubocop:enable RSpec/InstanceVariable
+
+    shared_examples 'with --no-puppet-env' do
+      context 'with --no-puppet-env' do
+        let(:cli_args){ super() << '--no-puppet-env' }
+        let(:puppet_hash_opts){ hash_including( enabled: false) }
+        include_examples 'a `simp environment new` command'
+      end
+    end
+
+    shared_examples 'with an additional --skeleton arg' do
+      context 'with --skeleton' do
+        let(:cli_args){ super() << '--skeleton'}
+        it do
+          expect{simp_env_new.call }.to raise_error(
+            Simp::Cli::ProcessingError,
+            'ERROR: Cannot specify more than one of: --skeleton, --copy, --link'
+          )
+        end
+      end
+    end
+
+    let(:normal_hash_opts){ hash_including(enabled: true, backend: :directory, strategy: :skeleton) }
+    let(:puppet_hash_opts){ normal_hash_opts }
+    let(:secondary_hash_opts){ normal_hash_opts }
+    let(:writable_hash_opts){ normal_hash_opts }
+    let(:expected_hash) do
+      hash_including(
+        types: hash_including(
+          puppet:    puppet_hash_opts,
+          secondary: secondary_hash_opts,
+          writable:  writable_hash_opts
+        )
+      )
+    end
+
+    context 'with `simp environment new development`' do
+      subject(:simp_env_new){ Proc.new { described_class.new.run(cli_args) } }
+      let(:cli_args){ ['development'] }
+      let(:expected_environment){ 'development' }
+
+      include_examples 'a `simp environment new` command'
+      include_examples 'with --no-puppet-env'
+      context 'with --skeleton' do
+        let(:cli_args){ super() << '--skeleton' }
+        include_examples 'a `simp environment new` command' # should be identical
+      end
+
+      context 'with --puppetfile --puppetfile-install' do
+        let(:cli_args){ super() << '--puppetfile' << '--puppetfile-install' }
+        let(:puppet_hash_opts) do
+          hash_including(enabled: true, strategy: :skeleton, puppetfile_generate: true, puppetfile_install: true )
+        end
+        include_examples 'a `simp environment new` command'
+        include_examples 'with --no-puppet-env'
+      end
+
+    end
+
+    context 'with `simp environment new staging --link production`' do
+      let(:cli_args){ [ 'staging', '--link', 'production' ] }
+      subject(:simp_env_new){ Proc.new { described_class.new.run(cli_args) } }
+      let(:expected_environment){ 'staging' }
+      let(:normal_hash_opts){ hash_including(enabled: true, backend: :directory, strategy: :link, src_env: 'production') }
+      let(:puppet_hash_opts) do
+        hash_including(
+          enabled: true, backend: :directory, strategy: :copy,
+          puppetfile_generate: false, puppetfile_install: false
+        )
+      end
+      include_examples 'a `simp environment new` command'
+      include_examples 'with --no-puppet-env'
+      include_examples 'with an additional --skeleton arg'
+    end
+
+    context 'with `simp environment new new_prod --copy production`' do
+      let(:cli_args){ [ 'new_prod', '--copy', 'production' ] }
+      subject(:simp_env_new){ Proc.new { described_class.new.run(cli_args) } }
+      let(:expected_environment){ 'new_prod' }
+      let(:normal_hash_opts){ hash_including(enabled: true, backend: :directory, strategy: :copy, src_env: 'production') }
+      include_examples 'a `simp environment new` command'
+      include_examples 'with --no-puppet-env'
+      include_examples 'with an additional --skeleton arg'
+    end
   end
 end

--- a/spec/lib/simp/cli/commands/environment/new_spec.rb
+++ b/spec/lib/simp/cli/commands/environment/new_spec.rb
@@ -8,10 +8,10 @@ require 'spec_helper'
 describe Simp::Cli::Commands::Environment::New do
   describe '#run' do
     context 'with default arguments' do
-      subject(:run) { proc { described_class.new.run([]) } }
-
       it 'requires an ENVIRONMENT argument' do
-        expect { run.call }.to raise_error(Simp::Cli::ProcessingError, %r{ENVIRONMENT.*is required})
+        expect { described_class.new.run([]) }.to raise_error(
+          Simp::Cli::ProcessingError, %r{ENVIRONMENT.*is required}
+      )
       end
     end
 
@@ -23,15 +23,179 @@ describe Simp::Cli::Commands::Environment::New do
       end
     end
 
+    context 'with mutually-exclusive arguments' do
+      strategies = [ ['--skeleton'], ['--copy', 'test_env2'], ['--link', 'test_env3']]
+      strategies.each do |first|
+        strategies.each do |second|
+          next if first == second
+
+          it "fails if #{first[0]} and #{second[0]} are both specified" do
+            expect { described_class.new.run(['test_env', first, second].flatten) }.to raise_error(
+              Simp::Cli::ProcessingError,
+              'ERROR: Cannot specify more than one of: --skeleton, --copy, --link'
+            )
+          end
+        end
+      end
+    end
+
+    # The next 4 hashes have the following structure:
+    #
+    # Key   = additional args to be passed to 'simp environment new'
+    # Value = expected changes to be made to the default options passed to the
+    #         OmniEnvController
+    skeleton_tests = {
+      [ '--skeleton' ]                        => {
+        :puppet      => {
+          :puppetfile_generate => true,
+          :puppetfile_install  => false
+        },
+        :description => 'create skeletons dirs and Puppetfiles'
+      },
+      [ '--skeleton', '--puppetfile-install'] => {
+        :puppet      => {
+          :puppetfile_generate => true,
+          :puppetfile_install  => true
+        },
+        :description => 'create skeletons dirs, create Puppetfiles, and deploy modules'
+      },
+      [ '--skeleton', '--no-puppet-env' ]     => {
+        :puppet      => { :enabled => false },
+        :description => 'create secondary and writable skeleton dirs only'
+      },
+      [ '--skeleton', '--no-secondary-env' ]  => {
+        :puppet      => { :puppetfile_generate => true },
+        :secondary   => { :enabled => false },
+        :description => 'create all but secondary skeletons dirs and create Puppetfiles'
+      },
+      [ '--skeleton', '--no-writable-env' ]   => {
+        :puppet      => { :puppetfile_generate => true },
+        :writable    => { :enabled => false },
+        :description => 'create all but writable skeletons dirs and create Puppetfiles'
+      },
+      [ '--skeleton', '--no-puppetfile-gen' ] => {
+        :puppet      => { :puppetfile_generate => false },
+        :description => 'only create skeletons dirs'
+      }
+    }
+
+    default_tests = {}
+    skeleton_tests.each do |args, expected_hash|
+      newargs = args.dup
+      newargs.delete('--skeleton')
+      default_tests[newargs] = expected_hash
+    end
+
+    copy_tests = {
+      [ '--copy', 'other_env' ]                        => {
+        :puppet      => { :strategy => :copy, :src_env => 'other_env'},
+        :secondary   => { :strategy => :copy, :src_env => 'other_env'},
+        :writable    => { :strategy => :copy, :src_env => 'other_env'},
+        :description => 'copy all env dirs'
+      },
+      [ '--copy', 'other_env', '--puppetfile-gen'] => {
+        :puppet      => {
+          :strategy             => :copy,
+          :src_env              => 'other_env',
+          :puppetfile_generate  => true
+        },
+        :secondary   => { :strategy => :copy, :src_env => 'other_env'},
+        :writable    => { :strategy => :copy, :src_env => 'other_env'},
+        :description => 'copy all env dirs and create Puppetfiles'
+      },
+      [ '--copy', 'other_env', '--puppetfile-install'] => {
+        :puppet       => {
+          :strategy            => :copy,
+          :src_env             => 'other_env',
+          :puppetfile_install  => true
+        },
+        :secondary   => { :strategy => :copy, :src_env => 'other_env'},
+        :writable    => { :strategy => :copy, :src_env => 'other_env'},
+        :description => 'copy all env dirs and deploy modules'
+      },
+      [ '--copy', 'other_env',  '--no-puppet-env' ]     => {
+        :puppet      => { :enabled => false, :strategy => :copy },
+        :secondary   => { :strategy => :copy, :src_env => 'other_env' },
+        :writable    => { :strategy => :copy, :src_env => 'other_env' },
+        :description => 'copy secondary and writable env dirs only'
+      },
+      [ '--copy', 'other_env', '--no-secondary-env' ]  => {
+        :puppet      => { :strategy => :copy, :src_env => 'other_env' },
+        :secondary   => { :enabled => false, :strategy => :copy },
+        :writable    => { :strategy => :copy, :src_env => 'other_env' },
+        :description => 'copy puppet and writable env dirs only'
+      },
+      [ '--copy', 'other_env', '--no-writable-env' ]   => {
+        :puppet      => { :strategy => :copy, :src_env => 'other_env' },
+        :secondary   => { :strategy => :copy, :src_env => 'other_env' },
+        :writable    => { :enabled => false, :strategy => :copy },
+        :description => 'copy puppet and secondary env dirs only'
+      }
+    }
+
+    link_tests = {
+      [ '--link', 'other_env' ]                        => {
+        :puppet      => { :strategy => :copy, :src_env => 'other_env'},
+        :secondary   => { :strategy => :link, :src_env => 'other_env'},
+        :writable    => { :strategy => :link, :src_env => 'other_env'},
+        :description => 'copy puppet dir and link secondary and writable dirs'
+      },
+      [ '--link', 'other_env', '--puppetfile-gen'] => {
+        :puppet      => {
+          :strategy             => :copy,
+          :src_env              => 'other_env',
+          :puppetfile_generate  => true
+        },
+        :secondary   => { :strategy => :link, :src_env => 'other_env'},
+        :writable    => { :strategy => :link, :src_env => 'other_env'},
+        :description => 'copy puppet dir, link secondary and writable dirs, and create Puppetfiles'
+      },
+      [ '--link', 'other_env', '--puppetfile-install'] => {
+        :puppet      => {
+          :strategy            => :copy,
+          :src_env             => 'other_env',
+          :puppetfile_install  => true
+        },
+        :secondary   => { :strategy => :link, :src_env => 'other_env'},
+        :writable    => { :strategy => :link, :src_env => 'other_env'},
+        :description => 'copy puppet dir, link secondary and writable dirs, and deploy modules'
+      },
+      [ '--link', 'other_env',  '--no-puppet-env' ]     => {
+        :puppet      => { :enabled => false, :strategy => :copy },
+        :secondary   => { :strategy => :link, :src_env => 'other_env' },
+        :writable    => { :strategy => :link, :src_env => 'other_env' },
+        :description => 'link secondary and writable dirs only'
+      },
+      [ '--link', 'other_env', '--no-secondary-env' ]  => {
+        :puppet      => { :strategy => :copy, :src_env => 'other_env' },
+        :secondary   => { :enabled => false, :strategy => :link },
+        :writable    => { :strategy => :link, :src_env => 'other_env' },
+        :description => 'copy puppet dir and  link writable dir only'
+      },
+      [ '--link', 'other_env', '--no-writable-env' ]   => {
+        :puppet      => { :strategy => :copy, :src_env => 'other_env' },
+        :secondary   => { :strategy => :link, :src_env => 'other_env' },
+        :writable    => { :enabled => false, :strategy => :link },
+        :description => 'copy puppet dir and link secondary dir only'
+      }
+    }
+
+    tests = {
+      :default  => default_tests,
+      :skeleton => skeleton_tests,
+      :copy     => copy_tests,
+      :link     => link_tests
+    }
+
     # rubocop:disable RSpec/InstanceVariable
-    shared_examples 'a `simp environment new` command' do
+    shared_examples 'a `simp environment new` command' do |comment|
       before :each do
         @spy = instance_double('OmniEnvController')
         allow(Simp::Cli::Environment::OmniEnvController).to receive(:new).and_return(@spy)
         allow(@spy).to receive(:create)
       end
 
-      it 'instantiates OmniEnvController with expected options' do
+      it "instantiates OmniEnvController to #{comment}" do
         simp_env_new.call
         expect(Simp::Cli::Environment::OmniEnvController).to have_received(:new).with(
           expected_hash, expected_environment
@@ -45,30 +209,40 @@ describe Simp::Cli::Commands::Environment::New do
     end
     # rubocop:enable RSpec/InstanceVariable
 
-    shared_examples 'with --no-puppet-env' do
-      context 'with --no-puppet-env' do
-        let(:cli_args){ super() << '--no-puppet-env' }
-        let(:puppet_hash_opts){ hash_including( enabled: false) }
-        include_examples 'a `simp environment new` command'
-      end
-    end
+    let(:default_puppet_hash_opts){ {
+      enabled: true,
+      strategy: :skeleton,
+      puppetfile_generate: false,
+      puppetfile_install: false,
+      backend: :directory,
+#      environmentpath: '/etc/puppetlabs/code/environments',
+      skeleton_path: '/usr/share/simp/environment-skeleton/puppet',
+      module_repos_path: '/usr/share/simp/git/puppet_modules',
+      skeleton_modules_path: '/usr/share/simp/modules',
+    } }
 
-    shared_examples 'with an additional --skeleton arg' do
-      context 'with --skeleton' do
-        let(:cli_args){ super() << '--skeleton'}
-        it do
-          expect{simp_env_new.call }.to raise_error(
-            Simp::Cli::ProcessingError,
-            'ERROR: Cannot specify more than one of: --skeleton, --copy, --link'
-          )
-        end
-      end
-    end
+    let(:default_secondary_hash_opts){ {
+      enabled: true,
+      strategy: :skeleton,
+      backend: :directory,
+      environmentpath: '/var/simp/environments',
+      skeleton_path: '/usr/share/simp/environment-skeleton/secondary',
+      rsync_skeleton_path: '/usr/share/simp/environment-skeleton/rsync',
+      tftpboot_src_path: '/var/www/yum/**/images/pxeboot',
+      tftpboot_dest_path: 'rsync/RedHat/Global/tftpboot/linux-install',
+    } }
 
-    let(:normal_hash_opts){ hash_including(enabled: true, backend: :directory, strategy: :skeleton) }
-    let(:puppet_hash_opts){ normal_hash_opts }
-    let(:secondary_hash_opts){ normal_hash_opts }
-    let(:writable_hash_opts){ normal_hash_opts }
+    let(:default_writable_hash_opts){ {
+      enabled: true,
+      strategy: :skeleton,
+      backend: :directory,
+#      environmentpath: '/opt/puppetlabs/server/data/puppetserver/simp/environments'
+    } }
+
+    let(:puppet_hash_opts){ hash_including(default_puppet_hash_opts) }
+    let(:secondary_hash_opts){ hash_including(default_secondary_hash_opts) }
+    let(:writable_hash_opts){  hash_including(default_writable_hash_opts) }
+
     let(:expected_hash) do
       hash_including(
         types: hash_including(
@@ -79,53 +253,39 @@ describe Simp::Cli::Commands::Environment::New do
       )
     end
 
-    context 'with `simp environment new development`' do
-      subject(:simp_env_new){ Proc.new { described_class.new.run(cli_args) } }
-      let(:cli_args){ ['development'] }
-      let(:expected_environment){ 'development' }
+    tests.each do |strategy, test_params|
+      context "with #{strategy} strategy" do
+        let(:expected_environment){ 'development' }
+        let(:base_cli_args) { [expected_environment, '--console-only'] }
 
-      include_examples 'a `simp environment new` command'
-      include_examples 'with --no-puppet-env'
-      context 'with --skeleton' do
-        let(:cli_args){ super() << '--skeleton' }
-        include_examples 'a `simp environment new` command' # should be identical
-      end
+        test_params.each do |args, expected_hash|
+          full_args = (['development', '--console-only'] << args).flatten
+          context "with args '#{full_args.join(' ')}'" do
+            subject(:simp_env_new){ Proc.new { described_class.new.run(cli_args) } }
+            let(:cli_args){ full_args }
+            let(:puppet_hash_opts) {
+              changes = expected_hash[:puppet]
+              changes = {} if changes.nil?
+              hash_including(default_puppet_hash_opts.merge(changes))
+            }
 
-      context 'with --puppetfile --puppetfile-install' do
-        let(:cli_args){ super() << '--puppetfile' << '--puppetfile-install' }
-        let(:puppet_hash_opts) do
-          hash_including(enabled: true, strategy: :skeleton, puppetfile_generate: true, puppetfile_install: true )
+            let(:secondary_hash_opts) {
+              changes = expected_hash[:secondary]
+              changes = {} if changes.nil?
+              hash_including(default_secondary_hash_opts.merge(changes))
+            }
+
+            let(:writable_hash_opts) {
+              changes = expected_hash[:writable]
+              changes = {} if changes.nil?
+              hash_including(default_writable_hash_opts.merge(changes))
+            }
+
+           include_examples 'a `simp environment new` command', expected_hash[:description]
+
+          end
         end
-        include_examples 'a `simp environment new` command'
-        include_examples 'with --no-puppet-env'
       end
-
-    end
-
-    context 'with `simp environment new staging --link production`' do
-      let(:cli_args){ [ 'staging', '--link', 'production' ] }
-      subject(:simp_env_new){ Proc.new { described_class.new.run(cli_args) } }
-      let(:expected_environment){ 'staging' }
-      let(:normal_hash_opts){ hash_including(enabled: true, backend: :directory, strategy: :link, src_env: 'production') }
-      let(:puppet_hash_opts) do
-        hash_including(
-          enabled: true, backend: :directory, strategy: :copy,
-          puppetfile_generate: false, puppetfile_install: false
-        )
-      end
-      include_examples 'a `simp environment new` command'
-      include_examples 'with --no-puppet-env'
-      include_examples 'with an additional --skeleton arg'
-    end
-
-    context 'with `simp environment new new_prod --copy production`' do
-      let(:cli_args){ [ 'new_prod', '--copy', 'production' ] }
-      subject(:simp_env_new){ Proc.new { described_class.new.run(cli_args) } }
-      let(:expected_environment){ 'new_prod' }
-      let(:normal_hash_opts){ hash_including(enabled: true, backend: :directory, strategy: :copy, src_env: 'production') }
-      include_examples 'a `simp environment new` command'
-      include_examples 'with --no-puppet-env'
-      include_examples 'with an additional --skeleton arg'
     end
   end
 end

--- a/spec/lib/simp/cli/config/items/action/configure_network_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/configure_network_action_spec.rb
@@ -3,12 +3,11 @@ require_relative '../spec_helper'
 
 describe Simp::Cli::Config::Item::ConfigureNetworkAction do
   before :each do
+    stub_const('Simp::Cli::SIMP_MODULES_INSTALL_PATH', '')
     @puppet_env_info = {
       :puppet_config => { 'modulepath' => '/some/module/path' }
     }
-
     @ci = Simp::Cli::Config::Item::ConfigureNetworkAction.new(@puppet_env_info)
-
     @cmd_prefix =  [
       'FACTER_ipaddress=XXX',
       'puppet apply',

--- a/spec/lib/simp/cli/config/items/action/set_grub_password_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/set_grub_password_action_spec.rb
@@ -4,6 +4,7 @@ require_relative '../spec_helper'
 
 describe Simp::Cli::Config::Item::SetGrubPasswordAction do
   before :each do
+    stub_const('Simp::Cli::SIMP_MODULES_INSTALL_PATH', '')
     @puppet_env_info = {
       :puppet_config => { 'modulepath' => '/some/module/path' }
     }

--- a/spec/lib/simp/cli/environment/dir_env_spec.rb
+++ b/spec/lib/simp/cli/environment/dir_env_spec.rb
@@ -34,7 +34,7 @@ describe Simp::Cli::Environment::DirEnv do
   context 'with methods' do
     subject(:described_object) { described_class.new(env_type, env_name, base_env_path, opts) }
 
-    describe '#selinux_fix_file_contexts', :skip => 'TODO: implement' do
+    describe '#selinux_fix_file_contexts' do
       it { expect { described_object.selinux_fix_file_contexts }.not_to raise_error }
     end
 

--- a/spec/lib/simp/cli/environment/dir_env_spec.rb
+++ b/spec/lib/simp/cli/environment/dir_env_spec.rb
@@ -105,7 +105,7 @@ describe Simp::Cli::Environment::DirEnv do
         # as user root
         allow(ENV).to receive(:fetch).with(any_args).and_call_original
         allow(ENV).to receive(:fetch).with('USER').and_return('root')
-        allow(described_object).to receive(:execute).with(rsync_cmd)
+        allow(described_object).to receive(:execute).with(rsync_cmd).and_return(true)
         allow($CHILD_STATUS).to receive(:success?).and_return(true)
       end
 
@@ -117,7 +117,7 @@ describe Simp::Cli::Environment::DirEnv do
   end
 
   describe '#fail_unless_createable' do
-    subject(:described_object) { described_class.new(env_name, base_env_path, opts) }
+    subject(:described_object) { described_class.new(:test, env_name, base_env_path, opts) }
     context 'when writable environment directory is empty' do
       before(:each) do
         allow(Dir).to receive(:glob).with(any_args).and_call_original

--- a/spec/lib/simp/cli/environment/omni_env_controller_spec.rb
+++ b/spec/lib/simp/cli/environment/omni_env_controller_spec.rb
@@ -68,11 +68,13 @@ describe Simp::Cli::Environment::OmniEnvController do
   describe '#create' do
     subject(:create) { proc { described_object.create } }
 
+    it_behaves_like 'it delegates to enabled Env objects', :fail_unless_createable, OMNI_ENVIRONMENT
     it_behaves_like 'it delegates to enabled Env objects', :create, OMNI_ENVIRONMENT
-    it_behaves_like 'it delegates to enabled Env objects', :fix, EXTRA_ENVIRONMENT
+    it_behaves_like 'it delegates to enabled Env objects', :fix,    EXTRA_ENVIRONMENT
     context 'when the Puppet environment is not enabled' do
       let(:opts) { opts_pup_disabled }
 
+      it_behaves_like 'it delegates to enabled Env objects', :fail_unless_createable, %i[secondary writable]
       it_behaves_like 'it delegates to enabled Env objects', :create, %i[secondary writable]
       it_behaves_like('it delegates to enabled Env objects', :fix, %i[secondary writable])
     end

--- a/spec/lib/simp/cli/environment/puppet_dir_env_spec.rb
+++ b/spec/lib/simp/cli/environment/puppet_dir_env_spec.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
 require 'simp/cli/environment/puppet_dir_env'
+require 'simp/cli/puppetfile/local_simp_puppet_modules'
+require 'simp/cli/puppetfile/skeleton'
+
 require 'spec_helper'
+require 'tmpdir'
 
 describe Simp::Cli::Environment::PuppetDirEnv do
   subject(:described_object) { described_class.new(env_name, base_env_path, opts) }
@@ -12,10 +16,9 @@ describe Simp::Cli::Environment::PuppetDirEnv do
     {
       puppetfile_generate: false,
       puppetfile_install: false,
-      deploy: false,
       backend: :directory,
       environmentpath: '/etc/puppetlabs/code/environments',
-      skeleton_path: "#{skel_dir}/simp",
+      skeleton_path: "#{share_dir}/environment-skeleton/puppet",
       module_repos_path: "#{share_dir}/git/puppet_modules",
       skeleton_modules_path: "#{share_dir}/modules"
     }
@@ -36,35 +39,23 @@ describe Simp::Cli::Environment::PuppetDirEnv do
     # rubocop:enable RSpec/MultipleExpectations
   end
 
-  describe '#copy_skeleton_files' do
-    let(:rsync_cmd) do
-      %(sg - puppet -c '/usr/bin/rsync -a --no-g "#{opts[:skeleton_path]}/" "#{env_dir}/" 2>&1')
-    end
-
-    before(:each) do
-      # as user root
-      allow(ENV).to receive(:fetch).with(any_args).and_call_original
-      allow(ENV).to receive(:fetch).with('USER').and_return('root')
-      allow(described_object).to receive(:execute).with(rsync_cmd).and_return(true)
-    end
-
-    example do
-      described_object.copy_skeleton_files(opts[:skeleton_path], env_dir, 'puppet')
-      expect(described_object).to have_received(:execute).with(rsync_cmd)
-    end
-  end
-
   context 'with methods' do
     describe '#create' do
+      before(:each) do
+        allow(Dir).to receive(:glob).with(File.join(env_dir, '*')).and_return([])
+      end
+
       context 'when strategy is :skeleton' do
         let(:opts){ super().merge(strategy: :skeleton) }
 
         before(:each) do
+          allow(described_object).to receive(:fail_unless_createable)
           allow(described_object).to receive(:create_environment_from_skeleton)
         end
         it { expect { described_object.create }.not_to raise_error }
         it {
           described_object.create
+          expect(described_object).to have_received(:fail_unless_createable)
           expect(described_object).to have_received(:create_environment_from_skeleton)
         }
       end
@@ -76,11 +67,15 @@ describe Simp::Cli::Environment::PuppetDirEnv do
             src_env:  File.join(base_env_path,'src_env'),
           })
         end
-        before(:each) { allow( described_object ).to receive(:copy_environment_files).with(opts[:src_env]) }
+        before(:each) do
+          allow(described_object).to receive(:fail_unless_createable)
+          allow(described_object).to receive(:create_environment_from_copy)
+        end
         it { expect { described_object.create }.not_to raise_error }
         example do
           described_object.create
-          expect(described_object).to have_received(:copy_environment_files).with(opts[:src_env])
+          expect(described_object).to have_received(:fail_unless_createable)
+          expect(described_object).to have_received(:create_environment_from_copy)
         end
       end
 
@@ -91,16 +86,35 @@ describe Simp::Cli::Environment::PuppetDirEnv do
             src_env:  File.join(base_env_path,'src_env'),
           })
         end
-        before(:each){ allow( described_object ).to receive(:link_environment_dirs).with(opts[:src_env]) }
+        before(:each) do
+          allow(described_object).to receive(:fail_unless_createable)
+          allow(described_object).to receive(:create_environment_from_link)
+        end
         it { expect { described_object.create }.not_to raise_error }
         example do
           described_object.create
-          expect(described_object).to have_received(:link_environment_dirs).with(opts[:src_env])
+          expect(described_object).to have_received(:fail_unless_createable)
+          expect(described_object).to have_received(:create_environment_from_link)
         end
       end
 
+      context 'when strategy is not set' do
+        before(:each) {
+          allow(described_object).to receive(:fail_unless_createable)
+        }
+        it {
+          expect { described_object.create }.to raise_error(
+            RuntimeError,
+            %r{ERROR: Unknown Puppet environment create strategy: ''}
+          )
+        }
+      end
+
       context 'when puppet environment directory is not empty' do
-        before(:each) { allow(Dir).to receive(:glob).and_return(['data', 'hiera.yaml']) }
+        let(:opts){ super().merge(strategy: :skeleton) }
+        before(:each) {
+          allow(Dir).to receive(:glob).with(File.join(env_dir, '*')).and_return(['data', 'hiera.yaml'])
+        }
         it {
           expect { described_object.create }.to raise_error(
             Simp::Cli::ProcessingError,
@@ -110,57 +124,220 @@ describe Simp::Cli::Environment::PuppetDirEnv do
       end
     end
 
-
-    describe '#create_environment_from_skeleton' do
-      context 'when puppet environment directory is empty (not deployed)' do
-        before(:each) do
-          allow(Dir).to receive(:glob).with(any_args).and_call_original
-          allow(Dir).to receive(:glob).with(File.join(env_dir, '*')).and_return([])
-          allow(FileUtils).to receive(:mkdir_p).with(any_args).and_call_original
-          allow(FileUtils).to receive(:mkdir_p).with(env_dir, mode: 0755)
-          allow(described_object).to receive(:copy_skeleton_files).with(
-            opts[:skeleton_path], env_dir, 'puppet'
-          )
-          allow(described_object).to receive(:template_environment_conf)
+    describe '#create_environment_from_copy' do
+      before(:each) { allow( described_object ).to receive(:copy_environment_files).with(opts[:src_env]) }
+      it { expect { described_object.create_environment_from_copy }.not_to raise_error }
+      example do
+        described_object.create_environment_from_copy
+        expect(described_object).to have_received(:copy_environment_files).with(opts[:src_env])
+      end
+      context 'with :puppetfile_generate option' do
+        let(:opts){ super().merge(puppetfile_generate: true)}
+        before :each do
+          allow(described_object).to receive(:puppetfile_generate)
         end
-
-        it { expect { described_object.create_environment_from_skeleton }.not_to raise_error }
         example do
-          described_object.create_environment_from_skeleton
-          expect(described_object).to have_received(:copy_skeleton_files).with(
-            opts[:skeleton_path], env_dir, 'puppet'
-          )
+          described_object.create_environment_from_copy
+          expect(described_object).to have_received(:puppetfile_generate).once
         end
-        it { expect { described_object.create_environment_from_skeleton }.not_to raise_error }
+      end
 
-        context 'with :puppetfile_generate option' do
-          let(:opts){ super().merge(puppetfile_generate: true)}
-          before :each do
-            allow(described_object).to receive(:puppetfile_generate)
-          end
-          example do
-            described_object.create_environment_from_skeleton
-            expect(described_object).to have_received(:puppetfile_generate).once
-          end
+      context 'with :puppetfile_install option' do
+        let(:opts){ super().merge(puppetfile_install: true)}
+        before :each do
+          allow(described_object).to receive(:puppetfile_install)
         end
-
-        context 'with :puppetfile_install option' do
-          let(:opts){ super().merge(puppetfile_install: true)}
-          before :each do
-            allow(described_object).to receive(:puppetfile_install)
-          end
-          example do
-            described_object.create_environment_from_skeleton
-            expect(described_object).to have_received(:puppetfile_install).once
-          end
+        example do
+          described_object.create_environment_from_copy
+          expect(described_object).to have_received(:puppetfile_install).once
         end
       end
     end
 
+    describe '#create_environment_from_link' do
+      before(:each){ allow( described_object ).to receive(:link_environment_dirs).with(opts[:src_env]) }
+      it { expect { described_object.create_environment_from_link }.not_to raise_error }
+      example do
+        described_object.create_environment_from_link
+        expect(described_object).to have_received(:link_environment_dirs).with(opts[:src_env])
+      end
+      context 'with :puppetfile_generate option' do
+        let(:opts){ super().merge(puppetfile_generate: true)}
+        before :each do
+          allow(described_object).to receive(:puppetfile_generate)
+        end
+        example do
+          described_object.create_environment_from_link
+          expect(described_object).to have_received(:puppetfile_generate).once
+        end
+      end
+
+      context 'with :puppetfile_install option' do
+        let(:opts){ super().merge(puppetfile_install: true)}
+        before :each do
+          allow(described_object).to receive(:puppetfile_install)
+        end
+        example do
+          described_object.create_environment_from_link
+          expect(described_object).to have_received(:puppetfile_install).once
+        end
+      end
+    end
+
+    describe '#create_environment_from_skeleton' do
+      before(:each) do
+        allow(FileUtils).to receive(:mkdir_p).with(any_args).and_call_original
+        allow(FileUtils).to receive(:mkdir_p).with(env_dir, mode: 0755)
+        allow(described_object).to receive(:copy_skeleton_files).with(
+          opts[:skeleton_path], env_dir, 'puppet'
+        )
+        allow(described_object).to receive(:template_environment_conf)
+      end
+
+      it { expect { described_object.create_environment_from_skeleton }.not_to raise_error }
+      example do
+        described_object.create_environment_from_skeleton
+        expect(described_object).to have_received(:copy_skeleton_files).with(
+          opts[:skeleton_path], env_dir, 'puppet'
+        )
+      end
+      it { expect { described_object.create_environment_from_skeleton }.not_to raise_error }
+
+      context 'with :puppetfile_generate option' do
+        let(:opts){ super().merge(puppetfile_generate: true)}
+        before :each do
+          allow(described_object).to receive(:puppetfile_generate)
+        end
+        example do
+          described_object.create_environment_from_skeleton
+          expect(described_object).to have_received(:puppetfile_generate).once
+        end
+      end
+
+      context 'with :puppetfile_install option' do
+        let(:opts){ super().merge(puppetfile_install: true)}
+        before :each do
+          allow(described_object).to receive(:puppetfile_install)
+        end
+        example do
+          described_object.create_environment_from_skeleton
+          expect(described_object).to have_received(:puppetfile_install).once
+        end
+      end
+    end
+
+    describe '#puppetfile_generate' do
+      let(:puppetfile_simp_content) { 'Puppetfile.simp content' }
+      let(:puppetfile_content) { 'Puppetfile content' }
+      before :each do
+        @tmp_dir  = Dir.mktmpdir( File.basename(__FILE__))
+        @env_name = 'test_env'
+        @opts = {
+          strategy: :skeleton,
+          puppetfile_generate: true,
+          backend: :directory,
+          environmentpath: File.join(@tmp_dir, 'puppet', 'environments'),
+          skeleton_path: File.join(@tmp_dir, 'skeleton', 'puppet'),
+          module_repos_path: File.join(@tmp_dir, 'puppet_modules'),
+          skeleton_modules_path: File.join(@tmp_dir, 'module')
+        }
+        FileUtils.mkdir_p(File.join(@opts[:environmentpath], @env_name))
+        @puppetfile = File.join(@opts[:environmentpath], @env_name, 'Puppetfile')
+        @puppetfile_simp = "#{@puppetfile}.simp"
+
+        allow(Simp::Cli::Puppetfile::LocalSimpPuppetModules).to receive(:new).and_return(
+          object_double('Fake LocalSimpPuppetModules', :to_puppetfile => puppetfile_simp_content)
+        )
+
+        allow(Simp::Cli::Puppetfile::Skeleton).to receive(:new).and_return(
+          object_double('Fake Skeleton', :to_puppetfile => puppetfile_content)
+        )
+
+      end
+
+      after :each do
+        FileUtils.remove_entry_secure @tmp_dir
+      end
+
+      it 'should generate Puppetfile.simp and Puppetfile when none exist' do
+        env_object = described_class.new(@env_name, @opts[:environmentpath], @opts)
+        env_object.puppetfile_generate
+
+        expect(File.exist?(@puppetfile)).to be true
+        expect(File.read(@puppetfile)).to eq "#{puppetfile_content}\n"
+        expect(File.exist?(@puppetfile_simp)).to be true
+        expect(File.read(@puppetfile_simp)).to eq "#{puppetfile_simp_content}\n"
+      end
+
+      it 'should generate Puppetfile.simp, only, when Puppetfile exists' do
+        File.open(@puppetfile, 'w') { |file| file.puts 'old Puppetfile content' }
+        env_object = described_class.new(@env_name, @opts[:environmentpath], @opts)
+        env_object.puppetfile_generate
+
+        expect(File.exist?(@puppetfile)).to be true
+        expect(File.read(@puppetfile)).to eq "old Puppetfile content\n"
+        expect(File.exist?(@puppetfile_simp)).to be true
+        expect(File.read(@puppetfile_simp)).to eq "#{puppetfile_simp_content}\n"
+      end
+
+      it 'should generate Puppetfile.simp only when both exist' do
+        File.open(@puppetfile, 'w') { |file| file.puts 'old Puppetfile content' }
+        File.open(@puppetfile_simp, 'w') { |file| file.puts 'old Puppetfile.simp content' }
+        env_object = described_class.new(@env_name, @opts[:environmentpath], @opts)
+        env_object.puppetfile_generate
+
+        expect(File.exist?(@puppetfile)).to be true
+        expect(File.read(@puppetfile)).to eq "old Puppetfile content\n"
+        expect(File.exist?(@puppetfile_simp)).to be true
+        expect(File.read(@puppetfile_simp)).to eq "#{puppetfile_simp_content}\n"
+      end
+    end
+
+    describe '#puppetfile_install' do
+      let(:r10k_cmd) { '/usr/share/simp/bin/r10k puppetfile install -v info' }
+      before :each do
+        @tmp_dir  = Dir.mktmpdir( File.basename(__FILE__))
+        @env_name = 'test_env'
+        @opts = {
+          strategy: :skeleton,
+          puppetfile_install: true,
+          backend: :directory,
+          environmentpath: File.join(@tmp_dir, 'puppet', 'environments'),
+          skeleton_path: File.join(@tmp_dir, 'skeleton', 'puppet'),
+          module_repos_path: File.join(@tmp_dir, 'puppet_modules'),
+          skeleton_modules_path: File.join(@tmp_dir, 'module')
+        }
+        FileUtils.mkdir_p(File.join(@opts[:environmentpath], @env_name))
+        allow(File).to receive(:executable?).with(any_args).and_call_original
+        allow(File).to receive(:executable?).with('/usr/share/simp/bin/r10k').and_return(true)
+      end
+
+      after :each do
+        FileUtils.remove_entry_secure @tmp_dir
+      end
+
+      it 'should execute r10K' do
+        env_object = described_class.new(@env_name, @opts[:environmentpath], @opts)
+        allow(env_object).to receive(:execute).with(r10k_cmd).and_return(true)
+        env_object.puppetfile_install
+        expect(env_object).to have_received(:execute).with(r10k_cmd)
+      end
+
+      it 'should fail when r10k fails' do
+        env_object = described_class.new(@env_name, @opts[:environmentpath], @opts)
+        allow(env_object).to receive(:execute).with(r10k_cmd).and_return(false)
+        expect { env_object.puppetfile_install }.to raise_error(
+          Simp::Cli::ProcessingError,
+          /ERROR:  Failed to install Puppet modules using r10k/
+        )
+      end
+    end
+
+    pending '#template_environment_conf'
+
     describe '#fix' do
       before(:each) do
         allow(File).to receive(:directory?).with(env_dir).and_return(true)
-        allow($stdout).to receive(:write)
       end
 
       context 'when puppet environment directory is present' do

--- a/spec/lib/simp/cli/environment/secondary_dir_env_spec.rb
+++ b/spec/lib/simp/cli/environment/secondary_dir_env_spec.rb
@@ -41,9 +41,44 @@ describe Simp::Cli::Environment::SecondaryDirEnv do
       allow(File).to receive(:exist?).with(opts[:environmentpath]).and_return(true)
     end
 
-    describe '#create', :skip => 'TODO implement' do
+    describe '#create' do
       before(:each) { allow(File).to receive(:exist?).with(env_dir).and_return(false) }
-      it { expect { described_object.create }.not_to raise_error }
+
+      context 'when strategy is :skeleton' do
+        let(:opts){ super().merge(strategy: :skeleton) }
+        before(:each){ allow(described_object).to receive(:create_environment_from_skeletons)}
+        it { expect { described_object.create }.not_to raise_error }
+      end
+
+      context 'when strategy is :copy' do
+        let(:opts) do
+          super().merge({
+            strategy: :copy,
+            src_env:  File.join(base_env_path,'src_env'),
+          })
+        end
+        before(:each) { allow( described_object ).to receive(:copy_environment_files).with(opts[:src_env]) }
+        it { expect { described_object.create }.not_to raise_error }
+        example do
+          described_object.create
+          expect(described_object).to have_received(:copy_environment_files).with(opts[:src_env])
+        end
+      end
+
+      context 'when strategy is :link' do
+        let(:opts) do
+          super().merge({
+            strategy: :link,
+            src_env:  File.join(base_env_path,'src_env'),
+          })
+        end
+        before(:each){ allow( described_object ).to receive(:link_environment_dirs).with(opts[:src_env]) }
+        it { expect { described_object.create }.not_to raise_error }
+        example do
+          described_object.create
+          expect(described_object).to have_received(:link_environment_dirs).with(opts[:src_env])
+        end
+      end
     end
 
     describe '#fix' do

--- a/spec/lib/simp/cli/puppetfile/local_simp_puppet_modules_spec.rb
+++ b/spec/lib/simp/cli/puppetfile/local_simp_puppet_modules_spec.rb
@@ -44,7 +44,7 @@ describe Simp::Cli::Puppetfile::LocalSimpPuppetModules do
   describe '#metadata_json_files' do
 
     it 'returns metadata.json files' do
-      expect( @local_modules.metadata_json_files ).to eq(
+      expect( @local_modules.metadata_json_files.sort ).to eq(
         [
           "#{@modules_install_dir}/simplib/metadata.json",
           "#{@modules_install_dir}/stdlib/metadata.json"
@@ -96,7 +96,7 @@ describe Simp::Cli::Puppetfile::LocalSimpPuppetModules do
     context 'when only valid modules are found in RPM install path' do
       it { expect( @local_modules.modules).to be_an Array }
       it { expect( @local_modules.modules.length).to be test_modules.keys.length }
-      it { expect( @local_modules.modules.first.to_s).to match %r{^mod 'simp-simplib',} }
+      it { expect( @local_modules.modules.sort{|a,b| a.to_s <=> b.to_s }.first.to_s).to match %r{^mod 'puppetlabs-stdlib',} }
     end
 
     context 'when invalid modules found in RPM install path' do


### PR DESCRIPTION
`simp environment new` changes:
- Behaviors match `--help` documentation:
  - `--skeleton` implies `--puppetfile`
  - `--puppetfile`:
    - generates `Puppetfile.simp` from local RPM/git repos
    - generates a skeleton `Puppetfile` (if needed)
- Fails before acting if any component environment cannot be created

SIMP-6662 #comment --puppetfile creates Puppetfile and Puppetfile.simp
SIMP-6662 #comment --skeleton implies --puppetfile
SIMP-6662 #close
SIMP-6663 #comment checks entire omni env before creating new envs
SIMP-6663 #close