### PR TITLE
(SIMP-6661) Handle existing example production env

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -12,7 +12,7 @@
 Summary: a cli interface to configure/manage SIMP
 Name: rubygem-%{gemname}
 Version: %{cli_version}
-Release: Alpha%{?dist}
+Release: 0%{?dist}
 Group: Development/Languages
 License: Apache-2.0
 URL: https://github.com/simp/rubygem-simp-cli
@@ -136,7 +136,7 @@ EOM
   - Added descriptions to top level help command list
 - 'simp puppetfile generate' changes:
   - Added '--local-modules ENV' option, which will add each local
-    local (unmanaged) module found in a Puppet environment to the
+    (unmanaged) module found in a Puppet environment to the
     generated skeleton Puppetfile as `:local => true`.  This option is
     key for sites that have unmanaged, locally-written modules in an
     environment. Without the local references, those modules will be

--- a/lib/simp/cli/commands/config.rb
+++ b/lib/simp/cli/commands/config.rb
@@ -215,7 +215,10 @@ EOM
       # the correct Puppet env info
       @options[:puppet_env_info] = Simp::Cli::Config::Item::DEFAULT_PUPPET_ENV_INFO
     else
-      env_helper = Simp::Cli::Config::SimpPuppetEnvHelper.new(@options[:puppet_env])
+      env_helper = Simp::Cli::Config::SimpPuppetEnvHelper.new(
+        @options[:puppet_env], @options[:start_time]
+      )
+
       status_code, status_details =  env_helper.env_status
       details_msg = status_details.split("\n").map { |line| '  >> ' + line }.join("\n")
 

--- a/lib/simp/cli/environment/secondary_dir_env.rb
+++ b/lib/simp/cli/environment/secondary_dir_env.rb
@@ -116,7 +116,7 @@ module Simp::Cli::Environment
 
     # Apply FACL permissions to a path using a file for `setfacl --restore`
     # @param [String] path       absolute path set FACLs
-    # @param [String] facl_file  absolutre path to rsync facl rules
+    # @param [String] facl_file  absolute path to rsync facl rules
     def apply_facls(path, facl_file)
       unless File.exist? @directory_path
         fail(


### PR DESCRIPTION
Workaround an issue in which the example, empty production
Puppet environment that is installed by the puppet-agent
RPM causes the OmniEnvController#create to fail.

SIMP-6661 #close