### PR TITLE
(SIMP-6681) simp puppetfile generate does not support upgrades

### DIFF
--- a/lib/simp/cli/commands/puppetfile/generate.rb
+++ b/lib/simp/cli/commands/puppetfile/generate.rb
@@ -42,7 +42,8 @@ class Simp::Cli::Commands::Puppetfile::Generate < Simp::Cli::Commands::Command
             with any other modules specified in it.
           - You can optionally have local modules in a specified environment
             automatically added to this parent Puppetfile.  Local modules are modules
-            whose directories are not under Git source control.
+            whose directories are not under Git source control and for which there
+            is no local Git repository.
 
         Usage:
 
@@ -55,8 +56,8 @@ class Simp::Cli::Commands::Puppetfile::Generate < Simp::Cli::Commands::Command
           simp puppetfile generate --skeleton > Puppetfile
 
           # Generate a Puppetfile that includes Puppetfile.simp and marks any unmanaged
-          # directories that exist under Puppet environment ENV's modules/ directory as
-          # `:local => true`
+          # directories that exist under Puppet environment ENV's modules/ directory
+          # and for which no local Git repository exists as `:local => true`
           simp puppetfile generate --skeleton --local-modules ENV > Puppetfile
 
         Options:
@@ -111,7 +112,10 @@ class Simp::Cli::Commands::Puppetfile::Generate < Simp::Cli::Commands::Command
     return if @help_requested
 
     if @puppetfile_type == :skeleton
-      puts Simp::Cli::Puppetfile::Skeleton.new(@puppet_env).to_puppetfile
+      puts Simp::Cli::Puppetfile::Skeleton.new(
+        @puppet_env,
+        @simp_modules_git_repos_path
+      ).to_puppetfile
     else
       puts Simp::Cli::Puppetfile::LocalSimpPuppetModules.new(
         @simp_modules_install_path,

--- a/spec/lib/simp/cli/commands/puppetfile/generate_spec.rb
+++ b/spec/lib/simp/cli/commands/puppetfile/generate_spec.rb
@@ -25,7 +25,8 @@ describe Simp::Cli::Commands::Puppetfile::Generate do
       let(:puppetfile) { 'Mocked Puppetfile content without local modules' }
 
       it 'prints skeleton Puppetfile to stdout' do
-        allow(Simp::Cli::Puppetfile::Skeleton).to receive(:new).with(nil).and_return(
+        allow(Simp::Cli::Puppetfile::Skeleton).to receive(:new).with(
+          nil, Simp::Cli::SIMP_MODULES_GIT_REPOS_PATH).and_return(
           object_double(
             Simp::Cli::Puppetfile::Skeleton.new(),
             :to_puppetfile => puppetfile
@@ -39,7 +40,8 @@ describe Simp::Cli::Commands::Puppetfile::Generate do
       let(:puppetfile) { 'Mocked Puppetfile content with local modules' }
 
       it 'prints skeleton Puppetfile with local modules to stdout' do
-        allow(Simp::Cli::Puppetfile::Skeleton).to receive(:new).with('production').and_return(
+        allow(Simp::Cli::Puppetfile::Skeleton).to receive(:new).with(
+         'production', Simp::Cli::SIMP_MODULES_GIT_REPOS_PATH).and_return(
           object_double(
             Simp::Cli::Puppetfile::Skeleton.new('production'),
             :to_puppetfile => puppetfile

--- a/spec/lib/simp/cli/puppetfile/files/malformed_metadata/metadata.json
+++ b/spec/lib/simp/cli/puppetfile/files/malformed_metadata/metadata.json
@@ -1,0 +1,2 @@
+{
+  "name": "local-extra1",

--- a/spec/lib/simp/cli/puppetfile/files/missing_name_metadata/metadata.json
+++ b/spec/lib/simp/cli/puppetfile/files/missing_name_metadata/metadata.json
@@ -1,5 +1,4 @@
 {
-  "name": "local-extra1",
   "version": "1.0.0",
   "author": "Local Team",
   "summary": "Local extra test module 1",

--- a/spec/lib/simp/cli/puppetfile/files/saz-timezone/metadata.json
+++ b/spec/lib/simp/cli/puppetfile/files/saz-timezone/metadata.json
@@ -1,0 +1,46 @@
+{
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat"
+    },
+    {
+      "operatingsystem": "CentOS"
+    },
+    {
+      "operatingsystem": "OracleLinux"
+    },
+    {
+      "operatingsystem": "Scientific"
+    },
+    {
+      "operatingsystem": "Debian"
+    },
+    {
+      "operatingsystem": "Ubuntu"
+    },
+    {
+      "operatingsystem": "Gentoo"
+    },
+    {
+      "operatingsystem": "ArchLinux"
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.9.1 < 6.0.0"
+    }
+  ],
+  "name": "saz-timezone",
+  "version": "5.1.1",
+  "source": "git://github.com/saz/puppet-timezone",
+  "author": "saz",
+  "license": "Apache-2.0",
+  "summary": "Manage timezone settings via Puppet",
+  "description": "Manage timezone settings via Puppet",
+  "project_page": "https://github.com/saz/puppet-timezone",
+  "dependencies": [
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0 < 6.0.0" },
+    { "name": "stm/debconf", "version_requirement": ">= 2.0.0 < 3.0.0" }
+  ]
+}

--- a/spec/lib/simp/cli/puppetfile/files/simp-timezone/metadata.json
+++ b/spec/lib/simp/cli/puppetfile/files/simp-timezone/metadata.json
@@ -1,0 +1,46 @@
+{
+  "name": "simp-timezone",
+  "version": "5.0.3",
+  "source": "git://github.com/simp/pupmod-simp-timezone",
+  "author": "SIMP Team",
+  "license": "Apache-2.0",
+  "summary": "Manage timezone settings via Puppet",
+  "description": "Manage timezone settings via Puppet",
+  "project_page": "https://github.com/simp/pupmod-simp-timezone",
+  "dependencies": [
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0 < 5.0.0" },
+    { "name": "stm/debconf", "version_requirement": ">= 2.0.0 < 3.0.0" }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 4.9.1 < 6.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "RedHat"
+    },
+    {
+      "operatingsystem": "CentOS"
+    },
+    {
+      "operatingsystem": "OracleLinux"
+    },
+    {
+      "operatingsystem": "Scientific"
+    },
+    {
+      "operatingsystem": "Debian"
+    },
+    {
+      "operatingsystem": "Ubuntu"
+    },
+    {
+      "operatingsystem": "Gentoo"
+    },
+    {
+      "operatingsystem": "ArchLinux"
+    }
+  ]
+}

--- a/spec/lib/simp/cli/puppetfile/skeleton_spec.rb
+++ b/spec/lib/simp/cli/puppetfile/skeleton_spec.rb
@@ -7,14 +7,28 @@ describe Simp::Cli::Puppetfile::Skeleton do
   # Set up the following tree in a tmp dir
   #
   #  +-- local_repos           <- bare local repos
-  #      +-- simplib.git
-  #      +-- stdlib.git
+  #      +-- simp-simplib.git
+  #      +-- puppetlabs-stdlib.git
+  #      +-- saz-timezone.git
   #  +-- environments_all_local_modules
   #      +-- testenv
   #          +-- modules
   #              +-- extra1
   #              +-- extra2
   #              +-- extra3   <- git project with no remote
+  #  +-- environments_local_modules_with_duplicates
+  #      +-- testenv
+  #          +-- modules
+  #              +-- extra1
+  #              +-- extra2
+  #              +-- simplib  <- no git but matches local_repos
+  #              +-- stdlib   <- no git but matches local_repos
+  #  +-- environments_local_modules_with_obsoletes
+  #      +-- testenv
+  #          +-- modules
+  #              +-- extra1
+  #              +-- extra2
+  #              +-- timezone <- simp-timezone obsoleted by saz-timezone
   #  +-- environments_no_local_modules
   #      +-- testenv
   #          +-- modules
@@ -48,6 +62,14 @@ describe Simp::Cli::Puppetfile::Skeleton do
         :environmentpath => File.join(@tmp_dir, 'environments_some_local_modules'),
         :modules_dir     => File.join(@tmp_dir, 'environments_some_local_modules', @puppet_env, 'modules')
       },
+      'local modules with duplicates' => {
+        :environmentpath => File.join(@tmp_dir, 'environments_local_modules_with_duplicates'),
+        :modules_dir     => File.join(@tmp_dir, 'environments_local_modules_with_duplicates', @puppet_env, 'modules')
+      },
+      'local modules with obsoletes' => {
+        :environmentpath => File.join(@tmp_dir, 'environments_local_modules_with_obsoletes'),
+        :modules_dir     => File.join(@tmp_dir, 'environments_local_modules_with_obsoletes', @puppet_env, 'modules')
+      },
       'all local modules' => {
         :environmentpath => File.join(@tmp_dir, 'environments_all_local_modules'),
         :modules_dir     => File.join(@tmp_dir, 'environments_all_local_modules', @puppet_env, 'modules')
@@ -56,12 +78,15 @@ describe Simp::Cli::Puppetfile::Skeleton do
 
     @environmentpaths.each_value { |paths| FileUtils.mkdir_p(paths[:modules_dir]) }
 
-    # create local (bare) git repos that will be cloned in module paths
+    # create local (bare) git repos that will be cloned in module paths or
+    # used for obsolete module evaluation
     test_files = File.join(__dir__, 'files')
-    simplib_repo_dir = File.join(@local_repo_dir, 'simplib.git')
+    simplib_repo_dir = File.join(@local_repo_dir, 'simp-simplib.git')
     TestUtils::Git::create_bare_repo(simplib_repo_dir, File.join(test_files, 'simplib', 'metadata.json'))
-    stdlib_repo_dir = File.join(@local_repo_dir, 'stdlib.git')
+    stdlib_repo_dir = File.join(@local_repo_dir, 'puppetlabs-stdlib.git')
     TestUtils::Git::create_bare_repo(stdlib_repo_dir, File.join(test_files, 'stdlib', 'metadata.json'))
+    timezone_repo_dir = File.join(@local_repo_dir, 'saz-timezone.git')
+    TestUtils::Git::create_bare_repo(timezone_repo_dir, File.join(test_files, 'saz-timezone', 'metadata.json'))
 
     # clone into module paths
     TestUtils::Git::clone_local_module_repo(simplib_repo_dir, @environmentpaths['no local modules'][:modules_dir])
@@ -82,6 +107,13 @@ describe Simp::Cli::Puppetfile::Skeleton do
     FileUtils.cp_r(File.join(test_files, 'extra2'), @environmentpaths['all local modules'][:modules_dir])
     FileUtils.cp_r(File.join(test_files, 'extra1'), @environmentpaths['some local modules'][:modules_dir])
     FileUtils.cp_r(File.join(test_files, 'extra2'), @environmentpaths['some local modules'][:modules_dir])
+    FileUtils.cp_r(File.join(test_files, 'extra1'), @environmentpaths['local modules with duplicates'][:modules_dir])
+    FileUtils.cp_r(File.join(test_files, 'extra2'), @environmentpaths['local modules with duplicates'][:modules_dir])
+    FileUtils.cp_r(File.join(test_files, 'simplib'), @environmentpaths['local modules with duplicates'][:modules_dir])
+    FileUtils.cp_r(File.join(test_files, 'stdlib'), @environmentpaths['local modules with duplicates'][:modules_dir])
+    FileUtils.cp_r(File.join(test_files, 'extra1'), @environmentpaths['local modules with obsoletes'][:modules_dir])
+    FileUtils.cp_r(File.join(test_files, 'extra2'), @environmentpaths['local modules with obsoletes'][:modules_dir])
+    FileUtils.cp_r(File.join(test_files, 'saz-timezone'), File.join(@environmentpaths['local modules with obsoletes'][:modules_dir], 'saz'))
   end
 
   after(:all) do
@@ -97,6 +129,26 @@ describe Simp::Cli::Puppetfile::Skeleton do
 
         #{Simp::Cli::Puppetfile::Skeleton::LOCAL_MODULE_SECTION}
 
+
+
+        #{Simp::Cli::Puppetfile::Skeleton::ROLES_PROFILES_SECTION}
+
+      PUPPETFILE
+    end
+
+    let(:expected_skeleton_with_extras) do
+      <<-PUPPETFILE.gsub(/ {8}/,'')
+        # ==============================================================================
+        # Puppetfile (Generated at YYYY-mm-dd HH:MM:SS with local modules from
+        # 'testenv' Puppet environment)
+        #
+        #{Simp::Cli::Puppetfile::Skeleton::INTRO_SECTION}
+        instance_eval(File.read(File.join(__dir__,"Puppetfile.simp")))
+
+
+        #{Simp::Cli::Puppetfile::Skeleton::LOCAL_MODULE_SECTION}
+        mod 'extra1', :local => true
+        mod 'extra2', :local => true
 
 
         #{Simp::Cli::Puppetfile::Skeleton::ROLES_PROFILES_SECTION}
@@ -129,7 +181,7 @@ describe Simp::Cli::Puppetfile::Skeleton do
           test_puppet_info = { :environment_path => @environmentpaths['no modules'][:environmentpath] }
           allow(Simp::Cli::Utils).to receive(:puppet_info).with(@puppet_env).and_return(test_puppet_info)
 
-          expect( Simp::Cli::Puppetfile::Skeleton.new(@puppet_env).to_puppetfile ).to eq expected_skeleton_only
+          expect( Simp::Cli::Puppetfile::Skeleton.new(@puppet_env, '/does/not/exist').to_puppetfile ).to eq expected_skeleton_only
         end
       end
 
@@ -138,7 +190,7 @@ describe Simp::Cli::Puppetfile::Skeleton do
           test_puppet_info = { :environment_path => @environmentpaths['no local modules'][:environmentpath] }
           allow(Simp::Cli::Utils).to receive(:puppet_info).with(@puppet_env).and_return(test_puppet_info)
 
-          expect( Simp::Cli::Puppetfile::Skeleton.new(@puppet_env).to_puppetfile ).to eq expected_skeleton_only
+          expect( Simp::Cli::Puppetfile::Skeleton.new(@puppet_env, '/does/not/exist').to_puppetfile ).to eq expected_skeleton_only
         end
       end
 
@@ -147,25 +199,32 @@ describe Simp::Cli::Puppetfile::Skeleton do
           test_puppet_info = { :environment_path => @environmentpaths['some local modules'][:environmentpath] }
           allow(Simp::Cli::Utils).to receive(:puppet_info).with(@puppet_env).and_return(test_puppet_info)
 
-          expected = <<-PUPPETFILE.gsub(/ {12}/,'')
-            # ==============================================================================
-            # Puppetfile (Generated at YYYY-mm-dd HH:MM:SS with local modules from
-            # 'testenv' Puppet environment)
-            #
-            #{Simp::Cli::Puppetfile::Skeleton::INTRO_SECTION}
-            instance_eval(File.read(File.join(__dir__,"Puppetfile.simp")))
+          expect( Simp::Cli::Puppetfile::Skeleton.new(@puppet_env, '/does/not/exist').to_puppetfile ).to eq expected_skeleton_with_extras
+        end
+      end
 
+      context 'when local modules with duplicates to local Git repos exist in the module path' do
+        it 'should generate skeleton Puppetfile with non-duplicate local modules' do
+          test_puppet_info = { :environment_path => @environmentpaths['local modules with duplicates'][:environmentpath] }
+          allow(Simp::Cli::Utils).to receive(:puppet_info).with(@puppet_env).and_return(test_puppet_info)
 
-            #{Simp::Cli::Puppetfile::Skeleton::LOCAL_MODULE_SECTION}
-            mod 'extra1', :local => true
-            mod 'extra2', :local => true
+          expect( Simp::Cli::Puppetfile::Skeleton.new(@puppet_env, @local_repo_dir).to_puppetfile ).to eq expected_skeleton_with_extras
+        end
+      end
 
+      context 'when local modules that have been obsoleted by local Git repos exist in the module path' do
+        it 'should generate skeleton Puppetfile with non-obsoleted local modules' do
+          test_puppet_info = { :environment_path => @environmentpaths['local modules with obsoletes'][:environmentpath] }
+          allow(Simp::Cli::Utils).to receive(:puppet_info).with(@puppet_env).and_return(test_puppet_info)
+          generator =  Simp::Cli::Puppetfile::Skeleton.new(@puppet_env, @local_repo_dir)
+          query_result = <<-EOM
+pupmod-simp-timezone < 5.0.3-0.obsolete
+pupmod-timezone < 5.1.1-0
+saz-timezone < 5.1.1-0
+          EOM
+          allow(generator).to receive(:`).with('rpm -q pupmod-saz-timezone').and_return(query_result)
 
-            #{Simp::Cli::Puppetfile::Skeleton::ROLES_PROFILES_SECTION}
-
-          PUPPETFILE
-
-          expect( Simp::Cli::Puppetfile::Skeleton.new(@puppet_env).to_puppetfile ).to eq expected
+          expect( generator.to_puppetfile ).to eq expected_skeleton_with_extras
         end
       end
 
@@ -193,7 +252,7 @@ describe Simp::Cli::Puppetfile::Skeleton do
 
           PUPPETFILE
 
-          expect( Simp::Cli::Puppetfile::Skeleton.new(@puppet_env).to_puppetfile ).to eq expected
+          expect( Simp::Cli::Puppetfile::Skeleton.new(@puppet_env, '/does/not/exist').to_puppetfile ).to eq expected
         end
       end
     end
@@ -201,11 +260,72 @@ describe Simp::Cli::Puppetfile::Skeleton do
     context "when the 'git' command could not be found" do
       it 'should fail' do
         allow(Facter::Core::Execution).to receive(:which).and_return(nil)
-        expect { Simp::Cli::Puppetfile::Skeleton.new(@puppet_env).to_puppetfile }.to raise_error(
+        expect { Simp::Cli::Puppetfile::Skeleton.new(@puppet_env, '/does/not/exist').to_puppetfile }.to raise_error(
           Simp::Cli::ProcessingError, /Could not find 'git' command/
         )
       end
     end
-
   end
+
+  describe '.load_metadata' do
+    let (:test_files) { File.join(__dir__, 'files') }
+
+    it 'should return metadata Hash when metadata.json is valid' do
+      generator = Simp::Cli::Puppetfile::Skeleton.new
+      expected = {
+        "author"                  => "Local Team",
+        "dependencies"            => [],
+        "issues_url"              => "https://simp-project.atlassian.net",
+        "license"                 => "Apache-2.0",
+        "name"                    => "local-extra1",
+        "operatingsystem_support" => [
+          {
+            "operatingsystem"        => "CentOS",
+            "operatingsystemrelease" => ["6", "7"]
+          }
+        ],
+        "project_page"            => "https://github.com/simp/pupmod-simp-extra1",
+        "requirements"            => [
+          {
+            "name"                => "puppet",
+            "version_requirement" => ">= 4.10.4 < 7.0.0"
+          }
+        ],
+        "source"                  => "https://github.com/simp/pupmod-simp-extra1",
+        "summary"                 => "Local extra test module 1",
+        "tags"                    => [],
+        "version"                 => "1.0.0"
+      }
+
+      # .send() to work around private method...
+      expect( generator.send(:load_metadata, File.join(test_files, 'extra1')) ).to eq expected
+    end
+
+    it 'should return nil Hash when metadata.json does not exist' do
+      generator = Simp::Cli::Puppetfile::Skeleton.new
+      expect( generator.send(:load_metadata, '/does/not/exist/module') ).to be_nil
+      expect{ generator.send(:load_metadata, '/does/not/exist/module') }.to output(
+        "Ignoring local module /does/not/exist/module: metadata.json missing\n"
+      ).to_stderr
+    end
+
+    it 'should return nil Hash when metadata.json is malformed' do
+      module_dir = File.join(test_files, 'malformed_metadata')
+      generator = Simp::Cli::Puppetfile::Skeleton.new
+      expect( generator.send(:load_metadata, module_dir) ).to be_nil
+      expect{ generator.send(:load_metadata, module_dir) }.to output(
+        /Ignoring local module #{Regexp.escape(module_dir)}/
+      ).to_stderr
+    end
+
+    it "should return nil Hash when metadata.json is missing top-level 'name' key" do
+      module_dir = File.join(test_files, 'missing_name_metadata')
+      generator = Simp::Cli::Puppetfile::Skeleton.new
+      expect( generator.send(:load_metadata, module_dir) ).to be_nil
+      expect{ generator.send(:load_metadata, module_dir) }.to output(
+        "Ignoring local module #{module_dir}: 'name' missing from metadata.json\n"
+      ).to_stderr
+    end
+  end
+
 end


### PR DESCRIPTION
`simp puppetfile generate --skeleton --local-modules ENV` now
excludes any local modules found in the specified environment for
which a local, SIMP-managed repo exists.

SIMP-6681 #comment rubygem-simp-cli