### PR TITLE
(SIMP-6828) Fix Secondary Environment for TFTP server

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -130,7 +130,9 @@ EOM
 
 %changelog
 * Thu Jul 11 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 5.0.1
-- Patched secondary environment permissions for tftp
+- Fixed a bug in which the tftpboot images copied into the rsync space in
+  SIMP's secondary environment were not world readable.  This prevented
+  clients from PXE booting.
 
 * Tue Jun 11 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0
 - Added 'simp environment' command

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -129,6 +129,9 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Thu Jul 11 2019 Michael Morrone <michael.morrone@onyxpoint.com> - 5.0.1
+- Patched secondary environment permissions for tftp
+
 * Tue Jun 11 2019 Chris Tessmer <chris.tessmer@onyxpoint.com> - 5.0.0
 - Added 'simp environment' command
 - Added `simp environment new` subcommand

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 5.0.0
+%global cli_version 5.0.1
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up

--- a/lib/simp/cli/environment/secondary_dir_env.rb
+++ b/lib/simp/cli/environment/secondary_dir_env.rb
@@ -161,6 +161,11 @@ module Simp::Cli::Environment
         dst_dirname = os_info.map(&:downcase).join('-')
         dst_path = File.join(@tftpboot_dest_path, dst_dirname)
         copy_skeleton_files(dir, dst_path, 'nobody')
+        # change perms to world readable or tftp fails
+        Dir.chdir(dst_path) do
+          FileUtils.chmod(0644, Dir.entries(dst_path) - %w[. ..])
+        end
+
 
         # create major OS version link
         os_info[1] = os_info[1].split('.').first

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '5.0.0'
+  VERSION = '5.0.1'
 end


### PR DESCRIPTION
Contents of linux-install/centos-7-x86_64 should be world readable

SIMP-6828 #close