### PR TITLE
(SIMP-7244) simp passgen prevent empty passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /vendor
 Gemfile.lock
 spec/lib/simp/cli/config/item/tmp/
+spec/fixtures
+.vagrant

--- a/Rakefile
+++ b/Rakefile
@@ -122,4 +122,8 @@ namespace :pkg do
 
   Rake::Task[:compare_latest_tag].enhance [:validate_ruby_version]
 end
+
+# Make sure gem packages are built because they will be installed in
+# the acceptance test
+Rake::Task['beaker:suites'].enhance ['pkg:gem']
 # vim: syntax=ruby

--- a/lib/simp/cli/commands/passgen.rb
+++ b/lib/simp/cli/commands/passgen.rb
@@ -70,7 +70,7 @@ class Simp::Cli::Commands::Passgen < Simp::Cli::Commands::Command
     if @operation == :show_environment_list
       show_environment_list
     else
-      # space at end tells logger to omit <CR>, so spinner+done is on same line
+      # space at end tells logger to omit <CR>, so spinner+done are on same line
       logger.notice("Initializing for environment '#{@environment}'... ")
       manager = nil
       Simp::Cli::Utils::show_wait_spinner {
@@ -440,7 +440,7 @@ class Simp::Cli::Commands::Passgen < Simp::Cli::Commands::Command
       end
 
       if remove
-        # space at end tells logger to omit <CR>, so spinner+done is on same
+        # space at end tells logger to omit <CR>, so spinner+done are on same
         # line
         logger.notice("Processing '#{name}' in #{manager.location}... ")
         begin
@@ -479,14 +479,17 @@ class Simp::Cli::Commands::Passgen < Simp::Cli::Commands::Command
   def set_passwords(manager, names, password_gen_options)
     errors = []
     names.each do |name|
-      # space at end tells logger to omit <CR>, so spinner+done is on same line
+      # space at end tells logger to omit <CR>, so spinner+done are on same line
       logger.notice("Processing '#{name}' in #{manager.location}... ")
       begin
         unless password_gen_options[:auto_gen]
           validate = password_gen_options[:validate]
-          logger.debug("Gathering password with validate=#{validate}")
+          min_length = password_gen_options[:minimum_length]
+          logger.debug("Gathering password with validate=#{validate} " +
+            "min_length=#{min_length}")
+
           password_gen_options[:password] =
-            Simp::Cli::Passgen::Utils::get_password(5, validate)
+            Simp::Cli::Passgen::Utils::get_password(5, validate, min_length)
         end
 
         password = nil
@@ -533,7 +536,7 @@ class Simp::Cli::Commands::Passgen < Simp::Cli::Commands::Command
   #   for any Puppet environment
   #
   def show_environment_list
-    # space at end tells logger to omit <CR>, so spinner+done is on same line
+    # space at end tells logger to omit <CR>, so spinner+done are on same line
     logger.notice('Looking for environments with simp-simplib installed... ')
     valid_envs = nil
     Simp::Cli::Utils::show_wait_spinner {
@@ -560,7 +563,7 @@ class Simp::Cli::Commands::Passgen < Simp::Cli::Commands::Command
   # @raise Simp::Cli::ProcessingError if retrieval of password list fails
   #
   def show_name_list(manager)
-    # space at end tells logger to omit <CR>, so spinner+done is on same line
+    # space at end tells logger to omit <CR>, so spinner+done are on same line
     logger.notice('Retrieving password names... ')
     begin
       names = nil
@@ -597,7 +600,7 @@ class Simp::Cli::Commands::Passgen < Simp::Cli::Commands::Command
   #   info for all names
   #
   def show_passwords(manager, names)
-    # space at end tells logger to omit <CR>, so spinner+done is on same line
+    # space at end tells logger to omit <CR>, so spinner+done are on same line
     logger.notice("Retrieving password information... ")
     results = []
     errors = []

--- a/spec/acceptance/shared_examples/simp_asset_manual_install.rb
+++ b/spec/acceptance/shared_examples/simp_asset_manual_install.rb
@@ -61,18 +61,28 @@ shared_examples 'simp asset manual install' do |master|
       on(master, "#{asset_staging_dir}/simp_selinux_policy/sbin/set_simp_selinux_policy install")
     end
 
+    it 'should install simp-cli and highline gems in /usr/share/simp/ruby' do
+      gemdir = '/usr/share/simp/ruby'
+      on(master, "mkdir -p #{gemdir}")
+      cmd_prefix = [
+        '/opt/puppetlabs/puppet/bin/gem',
+        'install',
+        '--local',
+        "--install-dir #{gemdir}",
+        '--force'
+      ].join(' ')
+
+      on(master, "#{cmd_prefix} #{asset_staging_dir}/rubygem_simp_cli/dist/simp-cli*gem")
+      on(master, "#{cmd_prefix} #{asset_staging_dir}/rubygem_simp_cli/dist/highline*gem")
+    end
+
     it "should install 'simp' script similar to that done by the rubygem-simp-cli RPM" do
-      # This is a ninja hack to create a working /bin/simp.  We don't
-      # need to create and install the gems in rubygem-simp-cli.  We
-      # simply need to create the script pointing to our staged
-      # rubygem-simp-cli clone.
-      #
       simp_script = <<-EOM
 #!/bin/bash
 
 PATH=/opt/puppetlabs/bin:/opt/puppetlabs/puppet/bin:$PATH
 
-#{asset_staging_dir}/rubygem_simp_cli/bin/simp $@
+/usr/share/simp/ruby/gems/simp-cli-*/bin/simp $@
 
       EOM
       create_remote_file(master, '/bin/simp', simp_script)

--- a/spec/lib/simp/cli/commands/passgen_spec.rb
+++ b/spec/lib/simp/cli/commands/passgen_spec.rb
@@ -344,15 +344,17 @@ Processing 'name4' in 'production' Environment... done.
         passwords << "#{name}_new_password"
       end
 
-      allow(Simp::Cli::Passgen::Utils).to receive(:get_password).with(5, false)
-        .and_return(*passwords)
+      allow(Simp::Cli::Passgen::Utils).to receive(:get_password)
+        .with(5, false, 8).and_return(*passwords)
 
       mock_manager = object_double('Mock Password Manager', {
         :set_password => nil,
         :location     => "'production' Environment"
       })
 
-      password_options = { :auto_gen => false, :validate => false }
+      password_options = { :auto_gen => false, :validate => false,
+        :minimum_length => 8 }
+
       names.each do |name|
         options = { :password => "#{name}_new_password" }
         options.merge!(password_options)
@@ -1366,7 +1368,8 @@ Processing 'name1' in 'dev' Environment, 'folder1' Folder, 'backend3' libkv Back
         end
 
         it 'sets passwords for names in default env using default options' do
-          allow(Simp::Cli::Passgen::Utils).to receive(:get_password).with(5, false)
+          allow(Simp::Cli::Passgen::Utils).to receive(:get_password)
+            .with(5, false, 8)
             .and_return('name1_new_password', 'name2_new_password')
 
           mock_manager = object_double('Mock LegacyPasswordManager', {
@@ -1437,7 +1440,8 @@ Processing 'name1' in 'dev' Environment... done.
         end
 
         it 'sets passwords for names in default env using default options' do
-          allow(Simp::Cli::Passgen::Utils).to receive(:get_password).with(5, false)
+          allow(Simp::Cli::Passgen::Utils).to receive(:get_password)
+            .with(5, false, 8)
             .and_return('name1_new_password', 'name2_new_password')
 
           mock_manager = object_double('Mock PasswordManager', {

--- a/spec/lib/simp/cli/passgen/utils_spec.rb
+++ b/spec/lib/simp/cli/passgen/utils_spec.rb
@@ -32,7 +32,7 @@ EOM
       expect(@output.string.uncolor).to eq expected
     end
 
-    it 're-prompts when the entered password fails validation' do
+    it 're-prompts when the entered password fails system validation' do
       @input << "short\n"
       @input << "#{password1}\n"
       @input << "#{password1}\n"
@@ -80,13 +80,37 @@ EOM
         .to raise_error(Simp::Cli::ProcessingError)
     end
 
-    it 'accepts an invalid password when validation disabled' do
+    it 'accepts an simple password when system validation disabled' do
       simple_password = 'password'
       @input << "#{simple_password}\n"
       @input << "#{simple_password}\n"
       @input.rewind
       expect( Simp::Cli::Passgen::Utils.get_password(5, false) )
         .to eq simple_password
+    end
+
+    it 'rejects a short password when system validation disabled' do
+      short_password = '12345678'
+      ok_password = '123456789'
+      @input << "#{short_password}\n"
+      @input << "#{short_password}\n"
+      @input << "#{ok_password}\n"
+      @input << "#{ok_password}\n"
+      @input.rewind
+      expect( Simp::Cli::Passgen::Utils.get_password(5, false, 9) )
+        .to eq ok_password
+   end
+  end
+
+  describe '.validate_password_length' do
+    it 'returns true when password has valid length' do
+      expect( Simp::Cli::Passgen::Utils.validate_password_length('1234', 4) )
+        .to be true
+    end
+
+    it 'returns false when password has invalid length' do
+      expect( Simp::Cli::Passgen::Utils.validate_password_length('1234', 5) )
+        .to be false
     end
   end
 


### PR DESCRIPTION
Fixed a 'simp passgen' bug in which it accepted an empty
password and then failed with an error message that was
meaningless to the user, when it attempted to set the
password via a 'puppet apply'.

* When libpwquality/cracklib validation is disabled, a user
  entered password is now validated for length prior to
  attempting to use it.
* Retooled simp-cli and highline gem installation to ensure
  the correct version of highline is used by simp-cli.
  The previous (hacked) install method resulted in the older
  version of highline packaged with puppet-agent being
  used, instead.