### PR TITLE
(SIMP-7533) Fix --dry-run issue with simp_conf.yaml

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -129,6 +129,11 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Tue Apr 07 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0
+- Fixed an issue where --dry-run would prompt the user to apply instead of
+  simply skipping to the (skipped) action items and then writing the
+  ~/.simp/simp_conf.yaml file
+
 * Fri Jan 03 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.0
 - Added simp kv command family to allow users to manage and inspect
   entries in a simpkv key/value store

--- a/lib/simp/cli/config/questionnaire.rb
+++ b/lib/simp/cli/config/questionnaire.rb
@@ -54,7 +54,9 @@ class Simp::Cli::Config::Questionnaire
 
   def process_pass2(deferred_queue, answers)
     logger.notice( "\n#{'='*80}\n" )
-    if !@options[:user_overrides] && @options[:allow_queries] && !@options[:force_defaults]
+    if @options[:allow_queries] && !(
+        @options[:dry_run] || @options[:user_overrides] || @options[:force_defaults]
+    )
       # space at end of question tells HighLine to remain on the prompt line
       # when gathering user input
       logger.notice("Questionnaire is now finished.\n".green)


### PR DESCRIPTION
- Fixed an issue where --dry-run would prompt the user to apply instead of
  simply skipping to the (skipped) action items and then writing the
  ~/.simp/simp_conf.yaml file

SIMP-7533 #close