### PR TITLE
[SIMP-6822] Migrate away from global 'classes'

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -129,10 +129,13 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
-* Tue Apr 07 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0
+* Wed Jun 22 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0
 - Fixed an issue where --dry-run would prompt the user to apply instead of
   simply skipping to the (skipped) action items and then writing the
   ~/.simp/simp_conf.yaml file
+- Ensure that `simp config` uses the `simp::classes` parameter instead
+  of `classes` by default
+- Accept both `simp::classes` and `classes` as valid existing configurations
 
 * Fri Jan 03 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.0
 - Added simp kv command family to allow users to manage and inspect

--- a/lib/simp/cli/config/items/action/hieradata_yaml_file_writer.rb
+++ b/lib/simp/cli/config/items/action/hieradata_yaml_file_writer.rb
@@ -41,7 +41,7 @@ module Simp::Cli::Config
               iostream.puts
             end
           elsif v.data_type == :global_class
-            # gather up the classes to be added to a  'classes' sequence at the end of the file
+            # gather up the classes to be added to a  'simp::classes' sequence at the end of the file
             global_classes << v.key
           end
         end
@@ -49,7 +49,7 @@ module Simp::Cli::Config
 
       unless global_classes.empty?
         iostream.puts
-        iostream.puts 'classes:'
+        iostream.puts 'simp::classes:'
         global_classes.each { |global_class| iostream.puts "  - #{global_class}" }
       end
     end

--- a/lib/simp/cli/config/items/action/warn_lockout_risk_action.rb
+++ b/lib/simp/cli/config/items/action/warn_lockout_risk_action.rb
@@ -102,9 +102,9 @@ in the `production` Puppet environment.  Execute these operations as `root`.
 
    Edit the SIMP server's YAML file,
    `/etc/puppetlabs/code/environments/production/data/<SIMP server FQDN>.yaml`
-   and add the `mymodule::local_user` to the `classes` array:
+   and add the `mymodule::local_user` to the `simp::classes` array:
 
-     classes:
+     simp::classes:
        - mymodule::local_user
 
 5. If the local user is configured to login with pre-shared keys instead of a

--- a/lib/simp/cli/config/items/add_server_class_action_item.rb
+++ b/lib/simp/cli/config/items/add_server_class_action_item.rb
@@ -27,10 +27,20 @@ module Simp::Cli::Config
         info( "Adding #{@class_to_add} to the class list in #{fqdn}.yaml file", [:GREEN] )
         yaml = IO.readlines(@file)
 
+        classes_key_regex = Regexp.new(/^simp::server::classes\s*:/)
+
+        unless yaml.find{|x| x.match?(classes_key_regex)}
+          classes_key_regex = Regexp.new(/^simp::classes\s*:/)
+        end
+
+        unless yaml.find{|x| x.match?(classes_key_regex)}
+          classes_key_regex = Regexp.new(/^classes\s*:/)
+        end
+
         File.open(@file, 'w') do |f|
           yaml.each do |line|
             line.chomp!
-            if line =~ /^classes\s*:/
+            if line.match?(classes_key_regex)
               f.puts line
               f.puts "  - '#{@class_to_add}'"
             else
@@ -51,7 +61,7 @@ module Simp::Cli::Config
 
     # whether a line from the YAML file contains the class
     def contains_class?(line)
-      return line.=~ /^\s*-\s+['"]*#{@class_to_add}['"]*/
+      return line.match?(/^\s*-\s+['"]*#{@class_to_add}['"]*/)
     end
   end
 end

--- a/lib/simp/cli/config/items/set_server_hieradata_action_item.rb
+++ b/lib/simp/cli/config/items/set_server_hieradata_action_item.rb
@@ -50,11 +50,22 @@ module Simp::Cli::Config
 
       info( "Adding #{hiera_key} to #{File.basename(@file)}" )
       yaml = IO.readlines(@file)
+
+      classes_key_regex = Regexp.new(/^simp::server::classes\s*:/)
+
+      unless yaml.find{|x| x.match?(classes_key_regex)}
+        classes_key_regex = Regexp.new(/^simp::classes\s*:/)
+      end
+
+      unless yaml.find{|x| x.match?(classes_key_regex)}
+        classes_key_regex = Regexp.new(/^classes\s*:/)
+      end
+
       line_written = false
       File.open(@file, 'w') do |f|
         yaml.each do |line|
           line.chomp!
-          if line =~ /^classes\s*:/
+          if line.match?(classes_key_regex)
             f.puts full_yaml_string
             f.puts line
             line_written = true

--- a/spec/lib/simp/cli/commands/files/environments/simp/data/hosts/puppet.your.domain.yaml
+++ b/spec/lib/simp/cli/commands/files/environments/simp/data/hosts/puppet.your.domain.yaml
@@ -59,6 +59,6 @@ rsyslog::udp_listen_address: '127.0.0.1'
 # puppetserver messages regarding node compile times, etc...
 # pupmod::master::log_level: INFO
 
-classes:
+simp::server::classes:
   - 'simp::server'
   - 'simp::puppetdb'

--- a/spec/lib/simp/cli/commands/files/environments/simp_hiera3/hieradata/scenarios/simp_lite.yaml
+++ b/spec/lib/simp/cli/commands/files/environments/simp_hiera3/hieradata/scenarios/simp_lite.yaml
@@ -39,7 +39,7 @@ simp_options::tcpwrappers: false
 simp_options::ipsec: false
 simp_options::kerberos: false
 
-classes:
+simp::classes:
   - 'aide'
   - 'auditd'
   # Virus scanning.

--- a/spec/lib/simp/cli/config/items/action/files/hieradata_yaml_file_writer_with_classes.yaml
+++ b/spec/lib/simp/cli/config/items/action/files/hieradata_yaml_file_writer_with_classes.yaml
@@ -36,7 +36,7 @@ simp_options::fips: false
 simp_options::puppet::server: puppet.domain.tld
 
 
-classes:
+simp::classes:
   - simp::yum::repo::internet_simp_dependencies
   - simp::yum::repo::local_os_updates
   - simp::yum::repo::local_simp

--- a/spec/lib/simp/cli/config/items/action/hieradata_yaml_file_writer_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/hieradata_yaml_file_writer_spec.rb
@@ -129,7 +129,7 @@ describe Simp::Cli::Config::Item::HieradataYAMLFileWriter do
       expect( @ci.applied_status ).to eq :succeeded
     end
 
-    it 'writes out a classes array when :global_class Items exist' do
+    it 'writes out a simp::classes array when :global_class Items exist' do
       item = Simp::Cli::Config::Item::SimpYumRepoInternetSimpDependenciesClass.new(@puppet_env_info)
       @ci.config_items[item.key] = item
 


### PR DESCRIPTION
* Ensure that `simp config` can handle the following in Hiera (in this
  priority order):
  * simp::server::classes
  * simp::classes
  * classes
* Ensure that the default output to the configuration file is
  `simp::classes` since it is meant to apply to all hosts by default.
* This change was tested via the `Vagrantfile` in `simp-core` and manual
  application.

SIMP-6822 #close