### PR TITLE
(SIMP-6936) Partial fix for setting initial env

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -129,7 +129,9 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
-* Wed Jun 22 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0
+* Thu Aug 13 2020 Trevor Vaughan <tvaughan@onyxpoint.com>
+- Allow users to set the SIMP_ENVIRONMENT environment variable to change the
+  initial environment from 'production' to a custom value
 - Fixed an issue where --dry-run would prompt the user to apply instead of
   simply skipping to the (skipped) action items and then writing the
   ~/.simp/simp_conf.yaml file

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -129,7 +129,7 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
-* Thu Aug 13 2020 Trevor Vaughan <tvaughan@onyxpoint.com>
+* Thu Aug 13 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0
 - Allow users to set the SIMP_ENVIRONMENT environment variable to change the
   initial environment from 'production' to a custom value
 - Fixed an issue where --dry-run would prompt the user to apply instead of

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -56,6 +56,7 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
 
     pupcmd = "puppet agent --onetime --no-daemonize --no-show_diff --verbose" +
       " --no-splay --agent_disabled_lockfile=#{agent_lockfile}" +
+      " --environment=#{Simp::Cli::BOOTSTRAP_PUPPET_ENV}" +
       " --masterport=#{@initial_puppetserver_port} --ca_port=#{@initial_puppetserver_port}"
 
     num_tagged_runs = 3
@@ -89,6 +90,7 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
     num_runs = 4
     info("Running puppet agent without tags #{num_runs} times...", 'cyan')
     pupcmd = 'puppet agent --onetime --no-daemonize --no-show_diff --verbose --no-splay' +
+      " --environment=#{Simp::Cli::BOOTSTRAP_PUPPET_ENV}" +
       " --agent_disabled_lockfile=#{agent_lockfile}"
     # This is ugly, but until we devise an intelligent way to determine when your system
     # is 'bootstrapped', we're going to run puppet in a loop.

--- a/lib/simp/cli/defaults.rb
+++ b/lib/simp/cli/defaults.rb
@@ -7,7 +7,7 @@ class Simp::Cli
 # Git to access SIMP asset files, such as those for the
 # simp-environment-skeleton.
   SIMP_CLI_HOME                  = "#{ENV['HOME']}/.simp"
-  BOOTSTRAP_PUPPET_ENV           = 'production'
+  BOOTSTRAP_PUPPET_ENV           = ENV.fetch('SIMP_ENVIRONMENT', 'production')
   BOOTSTRAP_START_LOCK_FILE      = File.join(SIMP_CLI_HOME, 'simp_bootstrap_start_lock')
   CONFIG_ANSWERS_OUTFILE         = File.join(SIMP_CLI_HOME, 'simp_conf.yaml')
   CONFIG_GLOBAL_HIERA_FILENAME   = 'simp_config_settings.yaml'


### PR DESCRIPTION
Allow users to set the SIMP_ENVIRONMENT environment variable to change
the initial environment from 'production' to a custom value

SIMP-6936 #comment Partial fix for setting the initial SIMP environment