### PR TITLE
(SIMP-8075)  Rake task not working

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,7 +55,7 @@ end
 
 # This project has unit tests in nonstandard locations, so redefine the
 # underlying Rake task to pick up its tests
-Rake::Task[:spec_standalone].clear
+Rake::Task[:spec_standalone].clear if Rake::Task.task_defined?(:spec_standalone)
 RSpec::Core::RakeTask.new(:spec_standalone) do |t|
   t.rspec_opts = ['--color']
   t.exclude_pattern = '**/{acceptance,fixtures,files}/**/*_spec.rb'

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 6.0.0
+%global cli_version 6.0.1
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up
@@ -129,6 +129,10 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Tue Sep 01 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.0.1
+- In Rakefile check if task spec_standalone exists before trying to
+  clear it
+
 * Thu Aug 13 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.0.0
 - Allow users to set the SIMP_ENVIRONMENT environment variable to change the
   initial environment from 'production' to a custom value

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '6.0.0'
+  VERSION = '6.0.1'
 end


### PR DESCRIPTION
- The Rake file attempts to clear out task spec_standalone but when building
  the ISO in rpm_docker this task, predefined by puppet, is
  not defined.  So check if the task is defined before trying
  to clear it

SIMP-8075 #comment   rubygem-simp-cli