### PR TITLE
(SIMP-8380) Fix typo in CLI error message

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 6.0.1
+%global cli_version 6.0.2
 %global highline_version 1.7.8
 
 # gem2ruby's method of installing gems into mocked build roots will blow up
@@ -129,6 +129,10 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Thu Sep 10 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.2
+- Fix a typo in an error message emitted when 'simp config' cannot
+  proceed because the environment to configure already exists.
+
 * Tue Sep 01 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.0.1
 - In Rakefile check if task spec_standalone exists before trying to
   clear it

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -639,7 +639,7 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
 
   # Track a running process by following its STDOUT output
   # Prints a '#' for each line of output
-  # returns -1 if error occured, otherwise the line count if PTY.spawn succeeded
+  # returns -1 if error occurred, otherwise the line count if PTY.spawn succeeded
   def track_output(command, port = nil)
     ensure_puppetserver_running(port)
     successful = true

--- a/lib/simp/cli/commands/config.rb
+++ b/lib/simp/cli/commands/config.rb
@@ -245,7 +245,7 @@ EOM
         # TODO Tell users to save off and then remove the Puppet and secondary
         #  environments that may exist, run 'simp config' again, and then restore
         #  any local customizations?
-        msg = "Unabled to configure: Invalid SIMP omni-environment for '#{@options[:puppet_env]}' exists:\n"
+        msg = "Unable to configure: Invalid SIMP omni-environment for '#{@options[:puppet_env]}' exists:\n"
         msg += details_msg
         raise Simp::Cli::ProcessingError.new(msg)
       end

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '6.0.1'
+  VERSION = '6.0.2'
 end

--- a/spec/bin/files/simp_config_full_stdin_file
+++ b/spec/bin/files/simp_config_full_stdin_file
@@ -18,4 +18,3 @@ no
 logserver1.test.local
 logserver2.test.local
 tty0
-yes

--- a/spec/lib/simp/cli/commands/config_spec_helper.rb
+++ b/spec/lib/simp/cli/commands/config_spec_helper.rb
@@ -32,9 +32,6 @@ def generate_simp_input_accepting_defaults(ask_if_ready = true)
     "\n"                          << # log servers
     "\n"                          << # securetty list
     "\n"                             # svckill warning mode
-  if ask_if_ready
-    input_io << "\n"                 # empty defaults to yes, we are ready to apply
-  end
   input_io.rewind
   input_io
 end
@@ -64,8 +61,7 @@ def generate_simp_lite_input_setting_values
     "LOCAL\n"                                 << # sssd domain
     "1.2.3.11\n"                              << # log servers
     "1.2.3.12\n"                              << # failover log servers
-    "tty0\n"                                  << # securetty list
-    "yes\n"                                      # we are ready to apply
+    "tty0\n"                                     # securetty list
   input_io.rewind
   input_io
 end
@@ -96,8 +92,7 @@ def generate_poss_input_setting_values
     "no\n"                << # use SSSD
     "1.2.3.11\n"          << # log servers
     "1.2.3.12\n"          << # failover log servers
-    "tty0\n"              << # securetty list
-    "yes\n"                  # we are ready to apply
+    "tty0\n"                 # securetty list
   input_io.rewind
   input_io
 end

--- a/spec/lib/simp/cli/config/items/action_item_spec.rb
+++ b/spec/lib/simp/cli/config/items/action_item_spec.rb
@@ -19,7 +19,7 @@ class MyActionItem < Simp::Cli::Config::ActionItem
     when :fail_no_raise
       @applied_status = :failed
     when :fail_raise
-      raise 'MyActionItem error occured'
+      raise 'MyActionItem error occurred'
     end
   end
 
@@ -76,7 +76,7 @@ describe Simp::Cli::Config::ActionItem do
       ci.apply_action = :fail_raise
 
       expect { ci.safe_apply }.to raise_error(Simp::Cli::Config::ApplyError,
-       'MyActionItem error occured')
+       'MyActionItem error occurred')
 
       expect(ci.applied_status).to eq :failed
     end


### PR DESCRIPTION
- Fixed a typo in an error message emitted when 'simp config' cannot
  proceed because the environment to configure already exists.
- Fixed stream input used in 'simp config' unit tests. The streams had
  extraneous, unread characters that should have been removed in an
  earlier dry-run-related bug fix.

SIMP-8380 #close