### PR TITLE
(SIMP-7238) simp environment new hides actual FACL failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -142,11 +142,14 @@ pup5.5.16:
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
-pup5.5.16-fips:
-  <<: *pup_5_5_16
-  <<: *acceptance_base
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
+# Re-enable after SIMP-8406 and SIMP-7305 are fixed. We don't even
+# want to run with allowed failure, because the attempt to reconnect
+# after reboot during FIPS setup can take more than an hour to timeout!
+#pup5.5.16-fips:
+#  <<: *pup_5_5_16
+#  <<: *acceptance_base
+#  script:
+#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
 pup5.5.16_simp_kv:
   <<: *pup_5_5_16
@@ -160,11 +163,14 @@ pup6:
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
-pup6-fips:
-  <<: *pup_6
-  <<: *acceptance_base
-  script:
-    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
+# Re-enable after SIMP-8406 and SIMP-7305 are fixed. We don't even
+# want to run with allowed failure, because the attempt to reconnect
+# after reboot during FIPS setup can take more than an hour to timeout!
+#pup6-fips:
+#  <<: *pup_6
+#  <<: *acceptance_base
+#  script:
+#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
 pup6_simp_kv:
   <<: *pup_6

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,3 @@
-# ------------------------------------------------------------------------------
-# NOTE: SIMP Puppet rake tasks support ruby 2.1.9
-# ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 gem_sources.each { |gem_source| source gem_source }
@@ -15,8 +12,16 @@ gem 'highline', :path => 'ext/gems/highline'
 gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>5')
 gem 'rake'
 gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.6', '< 6.0'])
+
+#FIXME SIMP-8406
+#gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']
 gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.12')
 gem 'r10k', ENV.fetch('R10k_VERSION',  '~>3')
+
+# FIXME Use released version when available.  This version has more robust
+# logic WRT reboot. It allows for same uptime after reboot, which can happen
+# on slow VMs.
+gem 'beaker', :git => 'https://github.com/voxpupuli/beaker', :ref => '2f03c5f'
 
 group :testing do
   # bootstrap common environment variables

--- a/Rakefile
+++ b/Rakefile
@@ -85,10 +85,21 @@ namespace :pkg do
       Dir.chdir gem_dir do
         Dir['*.gemspec'].each do |spec_file|
           cmd = %Q{SIMP_RPM_BUILD=1 bundle exec gem build "#{spec_file}" &> /dev/null}
-          ::Bundler.with_clean_env do
-            %x{bundle install}
-            sh cmd
+
+         if ::Bundler.respond_to?(:with_unbundled_env)
+            # Use Bundler 2.x API
+            ::Bundler.with_unbundled_env do
+              %x{bundle install}
+              sh cmd
+            end
+          else
+            # Use deprecated Bundler 1.x API
+            ::Bundler.with_clean_env do
+              %x{bundle install}
+              sh cmd
+            end
           end
+
           FileUtils.mkdir_p 'dist'
           FileUtils.mv Dir.glob('*.gem'), File.join(@rakefile_dir, 'dist')
         end

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -130,8 +130,10 @@ EOM
 
 %changelog
 * Thu Sep 10 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.2
-- Fix a typo in an error message emitted when 'simp config' cannot
+- Fixed a typo in an error message emitted when 'simp config' cannot
   proceed because the environment to configure already exists.
+- Fixed a bug in `simp environment new` in which the actual failure
+  messages from a failed `setfacl --restore` execution are not logged.
 
 * Tue Sep 01 2020 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.0.1
 - In Rakefile check if task spec_standalone exists before trying to

--- a/lib/simp/cli/environment/secondary_dir_env.rb
+++ b/lib/simp/cli/environment/secondary_dir_env.rb
@@ -119,7 +119,7 @@ module Simp::Cli::Environment
 
       Dir.chdir(path) do
         info("Applying FACL rules to '#{path}'".cyan)
-        cmd = "setfacl --restore=#{facl_file} 2>/dev/null"
+        cmd = "setfacl --restore=#{facl_file}"
         unless execute(cmd)
           fail(Simp::Cli::ProcessingError, "ERROR:  Failed to apply FACL rules to #{path}")
         end

--- a/spec/acceptance/helpers/beaker_workarounds.rb
+++ b/spec/acceptance/helpers/beaker_workarounds.rb
@@ -1,0 +1,33 @@
+module Acceptance
+  module Helpers
+    module BeakerWorkarounds
+
+      # Temporary, partial, hack until we have a good solution to beaker's ssh
+      # connection logic problems (as of beaker 4.11.0). That logic treats ssh
+      # connection timeouts from long running actions as failures...without any
+      # mechanism to configure just the connection timeout longer.
+      #
+      # All this method provides is a mechanism to work around a ssh connection
+      # failure *before* you run a command. So, place it in parts of the code
+      # where you have long running segments happening. It doesn't help if
+      # the ssh connection failure happens in the **middle** of a long-running
+      # segment.
+      def ensure_ssh_connection(host, reconnect_attempts = 3)
+        tries = reconnect_attempts
+        begin
+          on(host, 'uptime')
+        rescue Beaker::Host::CommandFailure => e
+          if e.message.include?('connection failure') && (tries > 0)
+            puts "Retrying due to << #{e.message.strip} >>"
+            tries -= 1
+            retry
+          else
+            raise e
+          end
+        end
+      end
+
+    end
+  end
+end
+

--- a/spec/acceptance/shared_examples/workaround_beaker_connectivity.rb
+++ b/spec/acceptance/shared_examples/workaround_beaker_connectivity.rb
@@ -1,0 +1,10 @@
+
+shared_examples 'workaround beaker ssh session closures' do |hosts|
+  hosts.each do |host|
+    context "ssh connection to #{host}" do
+      it 'should ensure ssh connection' do
+        ensure_ssh_connection(host)
+      end
+    end
+  end
+end

--- a/spec/acceptance/suites/default/00_simp_passgen_set_up_spec.rb
+++ b/spec/acceptance/suites/default/00_simp_passgen_set_up_spec.rb
@@ -4,25 +4,37 @@ test_name 'simp passgen set up'
 
 describe 'simp passgen set up' do
 
-  hosts.each do |host|
-    context 'Puppet master set up' do
+  context 'Puppet master set up' do
+    hosts.each do |host|
       include_examples 'fixtures move', host
+
+      include_examples 'workaround beaker ssh session closures', hosts
       include_examples 'simp asset manual install', host
+
+      include_examples 'workaround beaker ssh session closures', hosts
       include_examples 'passgen test environments set up', host
+
+      include_examples 'workaround beaker ssh session closures', hosts
       include_examples 'puppetserver set up', host
     end
+  end
 
-    context 'initial passgen secret generation' do
-      [
-        'old_simplib',
-        'new_simplib_legacy_passgen',
-        'new_simplib_simpkv_passgen'
-      ].each do |env|
+
+  context 'initial passgen secret generation' do
+    [
+      'old_simplib',
+      'new_simplib_legacy_passgen',
+      'new_simplib_simpkv_passgen'
+    ].each do |env|
+    hosts.each do |host|
         context 'puppet agent prep' do
+          include_examples 'workaround beaker ssh session closures', hosts
           include_examples 'configure puppet env', host, env
         end
 
         context 'puppet agent run' do
+          include_examples 'workaround beaker ssh session closures', hosts
+
           it 'should apply manifest to generate passwords and persist to files' do
             retry_on(host, 'puppet agent -t', :desired_exit_codes => [0],
               :max_retries => 5, :verbose => true.to_s)

--- a/spec/acceptance/suites/default/01_simp_passgen_list_ops_spec.rb
+++ b/spec/acceptance/suites/default/01_simp_passgen_list_ops_spec.rb
@@ -4,9 +4,8 @@ test_name 'simp passgen list operations'
 
 describe 'simp passgen list operations' do
 
-  hosts.each do |host|
-
-    context 'environment list' do
+  context 'environment list' do
+    hosts.each do |host|
       it 'should only list environments containing simp-simplib module' do
         result = on(host, 'simp passgen envs').stdout
         expect(result).to match(/old_simplib/)
@@ -15,21 +14,27 @@ describe 'simp passgen list operations' do
         expect(result).to_not match(/production/)
       end
     end
+  end
 
-    context 'password lists' do
-      let(:names) { [
-        'passgen_test_default',
-        'passgen_test_c0_8',
-        'passgen_test_c1_1024',
-        'passgen_test_c2_20',
-        'passgen_test_c2_only'
-      ] }
 
-      [
-        'old_simplib',
-        'new_simplib_legacy_passgen',
-        'new_simplib_simpkv_passgen'
-      ].each do |env|
+  context 'password lists' do
+    let(:names) { [
+      'passgen_test_default',
+      'passgen_test_c0_8',
+      'passgen_test_c1_1024',
+      'passgen_test_c2_20',
+      'passgen_test_c2_only'
+    ] }
+
+    [
+      'old_simplib',
+      'new_simplib_legacy_passgen',
+      'new_simplib_simpkv_passgen'
+    ].each do |env|
+      hosts.each do |host|
+
+        include_examples 'workaround beaker ssh session closures', hosts
+
         context "name list for #{env} environment" do
           it 'should list top folder names from passgen_test' do
             result = on(host, "simp passgen list -e #{env}").stdout

--- a/spec/acceptance/suites/default/03_simp_passgen_create_remove_passwords_spec.rb
+++ b/spec/acceptance/suites/default/03_simp_passgen_create_remove_passwords_spec.rb
@@ -9,13 +9,16 @@ test_name 'simp passgen create and remove passwords'
 describe 'simp passgen create and remove passwords' do
   let(:new_names) { ['passgen_test_default_new1', 'passgen_test_default_new2'] }
 
-  hosts.each do |host|
-    [
-      'old_simplib',
-      'new_simplib_legacy_passgen',
-      'new_simplib_simpkv_passgen'
-    ].each do |env|
+  [
+    'old_simplib',
+    'new_simplib_legacy_passgen',
+    'new_simplib_simpkv_passgen'
+  ].each do |env|
+    hosts.each do |host|
+
       context 'Password name creation' do
+        include_examples 'workaround beaker ssh session closures', hosts
+
         it "should create new passwords in #{env}" do
           new_names.each do |name|
             cmd = "simp passgen set #{name} -e #{env} --auto-gen"
@@ -33,12 +36,17 @@ describe 'simp passgen create and remove passwords' do
         end
       end
 
+
       context 'Use of externally created password in a manifest' do
+
         context 'puppet agent prep' do
+          include_examples 'workaround beaker ssh session closures', hosts
           include_examples 'configure puppet env', host, env
         end
 
         context 'puppet agent run' do
+          include_examples 'workaround beaker ssh session closures', hosts
+
           it 'should add extra passwords to passgen_test via hieradata' do
             default_yaml_file = File.join( '/etc/puppetlabs/code/environments',
                env, 'data', 'default.yaml')
@@ -70,6 +78,8 @@ describe 'simp passgen create and remove passwords' do
       end
 
       context 'Password name removal' do
+        include_examples 'workaround beaker ssh session closures', hosts
+
         it "should remove passwords in #{env}" do
           new_names.each do |name|
             cmd = "simp passgen remove #{name} -e #{env} --force"
@@ -82,6 +92,6 @@ describe 'simp passgen create and remove passwords' do
           end
         end
       end
-    end #[...].each do |env|
-  end # hosts.each
+    end # hosts.each
+  end #[...].each do |env|
 end #describe...

--- a/spec/acceptance/suites/default/04_simp_passgen_misc_spec.rb
+++ b/spec/acceptance/suites/default/04_simp_passgen_misc_spec.rb
@@ -1,16 +1,18 @@
 require 'spec_helper_acceptance'
 
-test_name 'simp passgen miscelleous'
+test_name 'simp passgen miscellaneous'
 
-describe 'simp passgen miscelleous' do
+describe 'simp passgen miscellaneous' do
 
-  hosts.each do |host|
 
-    [
-      'old_simplib',
-      'new_simplib_legacy_passgen',
-      'new_simplib_simpkv_passgen'
-    ].each do |env|
+  [
+    'old_simplib',
+    'new_simplib_legacy_passgen',
+    'new_simplib_simpkv_passgen'
+  ].each do |env|
+    hosts.each do |host|
+
+      include_examples 'workaround beaker ssh session closures', hosts
 
       if env == 'new_simplib_simpkv_passgen'
         context 'Specifying simpkv backend' do
@@ -92,6 +94,6 @@ describe 'simp passgen miscelleous' do
         end
       end
 
-    end #[...].each do |env|
-  end # hosts.each
+    end # hosts.each
+  end #[...].each do |env|
 end #describe...

--- a/spec/acceptance/suites/simp_kv/00_simp_cli_set_up_spec.rb
+++ b/spec/acceptance/suites/simp_kv/00_simp_cli_set_up_spec.rb
@@ -7,7 +7,11 @@ describe 'simp cli set up' do
   hosts.each do |host|
     context 'Puppet master set up' do
       include_examples 'fixtures move', host
+
+      include_examples 'workaround beaker ssh session closures', hosts
       include_examples 'simp asset manual install', host
+
+      include_examples 'workaround beaker ssh session closures', hosts
       include_examples 'puppetserver set up', host
     end
   end

--- a/spec/acceptance/suites/simp_kv/01_simp_kv_set_up_spec.rb
+++ b/spec/acceptance/suites/simp_kv/01_simp_kv_set_up_spec.rb
@@ -8,14 +8,20 @@ describe 'simp kv set up' do
     context 'environment set up' do
       include_examples 'kv test environments set up', host
     end
+  end
 
-    context 'initial key/value generation' do
-      [ 'production', 'dev' ].each do |env|
+  context 'initial key/value generation' do
+    [ 'production', 'dev' ].each do |env|
+      hosts.each do |host|
+
         context 'puppet agent prep' do
+          include_examples 'workaround beaker ssh session closures', hosts
           include_examples 'configure puppet env', host, env
         end
 
         context 'puppet agent runs' do
+          include_examples 'workaround beaker ssh session closures', hosts
+
           it 'should add test class to store key info in backends' do
            default_yaml_file = File.join( '/etc/puppetlabs/code/environments',
                env, 'data', 'default.yaml')

--- a/spec/acceptance/suites/simp_kv/10_simp_kv_exists_ops_spec.rb
+++ b/spec/acceptance/suites/simp_kv/10_simp_kv_exists_ops_spec.rb
@@ -47,6 +47,9 @@ describe 'simp kv exists operations' do
       'custom'  => '--backend custom'
     }.each do |backend, backend_opt|
       hosts.each do |host|
+
+        include_examples 'workaround beaker ssh session closures', hosts
+
         it "should report existence of #{env} env folders & keys in "\
            "#{backend} backend on #{host}" do
 

--- a/spec/acceptance/suites/simp_kv/20_simp_kv_list_ops_spec.rb
+++ b/spec/acceptance/suites/simp_kv/20_simp_kv_list_ops_spec.rb
@@ -12,6 +12,9 @@ describe 'simp kv list operations' do
       'custom'  => '--backend custom'
     }.each do |backend, backend_opt|
       hosts.each do |host|
+
+        include_examples 'workaround beaker ssh session closures', hosts
+
         context "brief list for #{env} env #{backend} backend on #{host}" do
           # default and custom backend list results only differ in the key
           # metadata, which is not present in the brief listing

--- a/spec/acceptance/suites/simp_kv/30_simp_kv_get_ops_spec.rb
+++ b/spec/acceptance/suites/simp_kv/30_simp_kv_get_ops_spec.rb
@@ -12,6 +12,9 @@ describe 'simp kv get operations' do
       'custom'  => '--backend custom'
     }.each do |backend, backend_opt|
       hosts.each do |host|
+
+        include_examples 'workaround beaker ssh session closures', hosts
+
         context "key get for #{env} env #{backend} on #{host}" do
           let(:keys_root_env) {
             keys_info('/', detailed_kv_list_results("#{backend} #{env}", false))

--- a/spec/acceptance/suites/simp_kv/40_simp_kv_put_ops_spec.rb
+++ b/spec/acceptance/suites/simp_kv/40_simp_kv_put_ops_spec.rb
@@ -18,6 +18,7 @@ describe 'simp kv put operations' do
     [ 'dev',        'custom',  '--backend custom' ]
   ].each do |env, backend, backend_opt|
     hosts.each do |host|
+
       context "modifying keys for #{env} env #{backend} backend on #{host}" do
         let(:created_key_names) { [] }
         let(:created_binary_key_names) { [] }
@@ -31,6 +32,7 @@ describe 'simp kv put operations' do
 
         let(:out_root_path) { "/var/kv_test/#{backend}" }
 
+        include_examples 'workaround beaker ssh session closures', hosts
         include_examples 'kv put modify operation test', host, env, backend_opt
         include_examples 'kv use created/modified keys test', host, env
       end
@@ -74,6 +76,7 @@ describe 'simp kv put operations' do
 
         let(:out_root_path) { "/var/kv_test/#{backend}" }
 
+        include_examples 'workaround beaker ssh session closures', hosts
         include_examples 'kv put create operation test', host, env, backend_opt
         include_examples 'kv use created/modified keys test', host, env
       end

--- a/spec/acceptance/suites/simp_kv/50_simp_kv_delete_ops_spec.rb
+++ b/spec/acceptance/suites/simp_kv/50_simp_kv_delete_ops_spec.rb
@@ -18,6 +18,8 @@ describe 'simp kv delete operations' do
     [ 'dev',        'custom',  '--backend custom' ]
   ].each do |env, backend, backend_opt|
     hosts.each do |host|
+      include_examples 'workaround beaker ssh session closures', hosts
+
       it "should delete #{env} env keys from #{backend} backend on #{host}" do
         cmd = "umask 0077; simp kv delete #{keys_env.join(',')} -e #{env} "\
               "#{backend_opt} --force"

--- a/spec/acceptance/suites/simp_kv/60_simp_kv_deletetree_ops_spec.rb
+++ b/spec/acceptance/suites/simp_kv/60_simp_kv_deletetree_ops_spec.rb
@@ -18,6 +18,8 @@ describe 'simp kv deletetree operations' do
     [ 'dev',        'custom',  '--backend custom' ]
   ].each do |env, backend, backend_opt|
     hosts.each do |host|
+      include_examples 'workaround beaker ssh session closures', hosts
+
       it "should delete #{env} env folders from #{backend} backend "\
          "on #{host}" do
         cmd = "umask 0077; simp kv deletetree #{folders_env.join(',')} "\

--- a/spec/acceptance/suites/simp_kv/70_simp_kv_errors_spec.rb
+++ b/spec/acceptance/suites/simp_kv/70_simp_kv_errors_spec.rb
@@ -14,6 +14,8 @@ describe 'simp kv errors' do
         'custom'  => '--backend custom'
       }.each do |backend, backend_opt|
         hosts.each do |host|
+          include_examples 'workaround beaker ssh session closures', hosts
+
           it "should fail list if folder does not exist in #{backend} "\
              "on #{host}" do
             cmd = "umask 0077; simp kv list #{invalid_folder} -e #{env} "\
@@ -53,6 +55,8 @@ describe 'simp kv errors' do
       let(:infile) { '/root/put.json' }
 
       hosts.each do |host|
+        include_examples 'workaround beaker ssh session closures', hosts
+
         it "should fail delete if backend is invalid in #{env} env "\
            "on #{host}" do
           cmd = "umask 0077; simp kv delete #{key} -e #{env} "\

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,6 +7,7 @@ require 'yaml'
 require 'simp/beaker_helpers'
 
 include Simp::BeakerHelpers
+include Acceptance::Helpers::BeakerWorkarounds
 include Acceptance::Helpers::EnvHelper
 include Acceptance::Helpers::KvTestData
 


### PR DESCRIPTION
* Fixed a bug in `simp environment new` in which the actual failure
  messages from a failed `setfacl --restore` execution are not logged.
  * The underlying `execute()` function will capture and log the
    error messages when the command fails.
* Restructured acceptance tests to try to workaround beaker random
  ssh disconnects on slow GitLab servers.
  * These workarounds don't solve the problem, but reduce it.
  * Need beaker support to set ssh keepalive settings to solve the
    problem.
* Temporarily disabled FIPS-mode acceptance tests until the local HighLine
  gem can be updated to version >= 2.0.0.
  * Bundler will fail with the version of simp-beaker-helpers required
    to fix the FIPS-mode setup bug. (See SIMP-8406).
  * The tests can take more than an hour to fail.
* Added support for Bundler 2.x and 1.x APIs in the Rakefile.
  * Use Bundler.with_bundled_env in lieu of deprecated
    Bundler.with_clean_env when bundling with 2.x

SIMP-7238 #close