### PR TITLE
(SIMP-8383) simp cli uses wrong local sssd domain

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,11 +16,6 @@ gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.6', '< 6.
 gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']
 gem 'r10k', ENV.fetch('R10k_VERSION',  '~>3')
 
-# FIXME Use released version when available.  This version has more robust
-# logic WRT reboot. It allows for same uptime after reboot, which can happen
-# on slow VMs.
-gem 'beaker', :git => 'https://github.com/voxpupuli/beaker', :ref => '2f03c5f'
-
 group :testing do
   # bootstrap common environment variables
   gem 'dotenv'

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 6.0.2
+%global cli_version 6.0.3
 %global highline_version 2.0.3
 
 # gem2ruby's method of installing gems into mocked build roots will blow up
@@ -129,6 +129,12 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Tue Sep 30 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.3
+- Fixed a bug where 'simp config' recommended the wrong SSSD domain,
+  when the SIMP server was not the LDAP server.  It recommended the
+  'Local' domain, when the appropriate SIMP-created domain with the
+  'local' (EL6) or 'files' (EL7) provider is 'LOCAL'.
+
 * Thu Sep 10 2020 Liz Nemsick <lnemsick.simp@gmail.com> - 6.0.2
 - Fixed a typo in an error message emitted when 'simp config' cannot
   proceed because the environment to configure already exists.
@@ -177,7 +183,6 @@ EOM
     - '--[no-]complex-only': Whether to only use only complex characters
       when a password is auto-generated. Corresponds to the complex_only
       option of simplib::passgen.
-      key/value store.
     - '--[no-]validate': Enabled validation of new passwords with
       libpwquality/cracklib.
     - '--length': Password length to use when a password is auto-generated.

--- a/lib/simp/cli/config/items/data/sssd_domains.rb
+++ b/lib/simp/cli/config/items/data/sssd_domains.rb
@@ -10,10 +10,13 @@ module Simp::Cli::Config
       @key         = 'sssd::domains'
       @description = %Q{A list of domains for SSSD to use.
 
-* When you are using SIMP-provided LDAP, this field should include `LDAP`,
-  the name of the SSSD domain SIMP creates.
-* Otherwise, this field must be a valid domain ('Local' and/or a custom
-  domain) or the sssd service will fail to start.
+* When you are using SIMP-provided LDAP, this field should include 'LDAP',
+  the name of the SSSD domain SIMP creates with the 'ldap' provider.
+* This field may include 'LOCAL', to use the domain SIMP creates with
+  the 'local' provider for EL6 or the 'files' provider for EL7.
+
+IMPORTANT: For EL < 8, this field *MUST* have a valid domain or the sssd
+service will fail to start.
 }
     end
 
@@ -26,8 +29,11 @@ module Simp::Cli::Config
         # of the domain setup in the `simp` module.
         ['LDAP']
       else
-        # make sure set to something valid, or sssd will not start
-        ['Local']
+        if Facter.value('os')['release']['major'] < "8"
+          ['LOCAL']
+        else
+          []
+        end
       end
     end
 

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '6.0.2'
+  VERSION = '6.0.3'
 end

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -15,20 +15,20 @@ HOSTS:
     platform: el-6-x86_64
     box: centos/6
     hypervisor: <%= hypervisor %>
-    vagrant_memsize: 4608
-    vagrant_cpus: 2
-
   el7:
     roles:
       - client
     platform: el-7-x86_64
     box: centos/7
     hypervisor: <%= hypervisor %>
-    vagrant_memsize: 4608
-    vagrant_cpus: 2
 
 CONFIG:
   log_level: verbose
+  vagrant_memsize: 4608
+  vagrant_cpus: 2
+  ssh:
+    keepalive: true
+    keepalive_interval: 1
   synced_folder : disabled
   type: aio
 

--- a/spec/lib/simp/cli/commands/config_run_spec.rb
+++ b/spec/lib/simp/cli/commands/config_run_spec.rb
@@ -49,6 +49,11 @@ describe 'Simp::Cli::Command::Config#run' do
       allow(Facter).to receive(:value).with(fact_name).and_return(facts[fact_name])
     end
 
+    # Needed to ensure we execute expected decision tree paths
+    iso_repo ='/etc/yum.repos.d/simp_filesystem.repo'
+    allow(File).to receive(:exist?).with(any_args).and_call_original
+    allow(File).to receive(:exist?).with(iso_repo).and_return(false)
+
     @input = TestUtils::StringIO.new
     @output = TestUtils::StringIO.new
     HighLine.default_instance = HighLine.new(@input, @output)

--- a/spec/lib/simp/cli/commands/config_spec_helper.rb
+++ b/spec/lib/simp/cli/commands/config_spec_helper.rb
@@ -3,7 +3,6 @@ require 'yaml'
 
 # Create TestUtils::StringIO corresponding to user input for the simp
 # scenario in which the default values are accepted.
-# FIXME:  This input is INCORRECT if /etc/yum.repos.d/simp_filesystem.repo exists.
 def generate_simp_input_accepting_defaults(ask_if_ready = true)
   input_io = TestUtils::StringIO.new
   if ask_if_ready
@@ -40,7 +39,6 @@ end
 # Create TestUtils::StringIO corresponding to user input for the simp_lite
 # scenario in which the most values are set to user-provided values.
 # Exercises LDAP-enabled, but non-LDAP server logic.
-# FIXME:  This input is INCORRECT if /etc/yum.repos.d/simp_filesystem.repo exists.
 def generate_simp_lite_input_setting_values
   input_io = TestUtils::StringIO.new
   input_io                                    <<
@@ -71,7 +69,6 @@ end
 # scenario in which most values are set to user-provided values.
 # Exercises LDAP-disabled and SSSD-disabled logic.
 # via user input.
-# FIXME:  This input is INCORRECT if /etc/yum.repos.d/simp_filesystem.repo exists.
 def generate_poss_input_setting_values
   input_io = TestUtils::StringIO.new
   input_io                <<

--- a/spec/lib/simp/cli/config/items/action/set_hostname_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/set_hostname_action_spec.rb
@@ -7,22 +7,22 @@ describe Simp::Cli::Config::Item::SetHostnameAction do
     @ci = Simp::Cli::Config::Item::SetHostnameAction.new
   end
 
-  # TODO:  test successes with acceptance tests
-  describe "#apply" do
-    it "will do set hostname " do
+  # TODO:  test with acceptance tests
+  describe '#apply' do
+    it 'will do set hostname ' do
       cli_network_hostname = Simp::Cli::Config::Item::CliNetworkHostname.new
       cli_network_hostname.value = 'foo.bar.baz'
+      cli_network_dhcp = Simp::Cli::Config::Item::CliNetworkDHCP.new
+      cli_network_dhcp.value = 'static'
+      @ci.config_items = {
+        cli_network_hostname.key => cli_network_hostname,
+        cli_network_dhcp.key => cli_network_dhcp
+      }
 
-      expect(@ci).to receive(:get_item).with('cli::network::hostname').and_return(cli_network_hostname)
       expect(@ci).to receive(:execute).with("hostname #{cli_network_hostname.value}").and_return(true)
       expect(@ci).to receive(:execute).with("sed -i '/HOSTNAME/d' /etc/sysconfig/network").and_return(true)
       expect(@ci).to receive(:execute).with("echo HOSTNAME=#{cli_network_hostname.value} >> /etc/sysconfig/network").and_return(true)
       expect(File).to receive(:open).with('/etc/hostname', 'w')
-
-      cli_network_dhcp = Simp::Cli::Config::Item::CliNetworkDHCP.new
-      cli_network_dhcp.value = 'static'
-
-      expect(@ci).to receive(:get_item).with('cli::network::dhcp').and_return(cli_network_dhcp)
 
       @ci.apply
 
@@ -33,12 +33,14 @@ describe Simp::Cli::Config::Item::SetHostnameAction do
       cli_network_hostname = Simp::Cli::Config::Item::CliNetworkHostname.new
       cli_network_hostname.value = 'oops.test.local'
       @ci.config_items = { cli_network_hostname.key => cli_network_hostname }
+
+      expect(@ci).to receive(:execute).with("hostname #{cli_network_hostname.value}").and_return(false)
       @ci.apply
       expect( @ci.applied_status ).to eq :failed
     end
   end
 
-  describe "#apply_summary" do
+  describe '#apply_summary' do
     it 'reports unattempted status when #apply not called' do
       expect(@ci.apply_summary).to eq 'Setting of hostname unattempted'
     end

--- a/spec/lib/simp/cli/config/items/action/update_os_yum_repositories_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/update_os_yum_repositories_action_spec.rb
@@ -3,7 +3,7 @@ require 'rspec/its'
 require_relative '../spec_helper'
 
 describe Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction do
-  context "in a SIMP directory structure" do
+  context 'in a SIMP directory structure' do
     before :each do
       @files_dir   = File.expand_path( 'files', File.dirname( __FILE__ ) )
       @tmp_dir     = Dir.mktmpdir( File.basename( __FILE__ ) )
@@ -17,6 +17,14 @@ describe Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction do
       @ci.www_yum_dir = @tmp_yum_dir
       @ci.yum_repos_d = @tmp_repos_d
       @ci.silent      =  true  # comment out this line to see log output
+
+      chown_cmd = "chown -R root:apache #{@tmp_yum_dir}/"
+      allow(@ci).to receive(:execute).with(any_args).and_call_original
+      allow(@ci).to receive(:execute).with(chown_cmd).and_return(true)
+    end
+
+    after :each do
+      FileUtils.remove_entry_secure @tmp_dir
     end
 
     describe '#apply' do
@@ -34,7 +42,7 @@ describe Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction do
                                      @fake_facts['operatingsystemrelease'],
                                      @fake_facts['architecture']
                                    )
-        FileUtils.remove_entry_secure @yum_dist_dir if File.exists? @yum_dist_dir
+
         FileUtils.mkdir_p @yum_dist_dir
       end
 
@@ -59,12 +67,11 @@ describe Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction do
 
       after :each do
         @fake_facts.each{ |k,v| ENV.delete "FACTER_#{k}" }
-        FileUtils.remove_entry_secure @tmp_dir
       end
     end
   end
 
-  context "not in SIMP directory structure" do
+  context 'not in SIMP directory structure' do
     before :each do
       @tmp_dir     = Dir.mktmpdir( File.basename( __FILE__ ) )
       @tmp_yum_dir = File.expand_path( 'yum',   @tmp_dir )
@@ -75,6 +82,10 @@ describe Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction do
       @ci.www_yum_dir = @tmp_yum_dir
       @ci.yum_repos_d = @tmp_repos_d
       @ci.silent      =  true  # comment out this line to see log output
+
+      chown_cmd = "chown -R root:apache #{@tmp_yum_dir}/"
+      allow(@ci).to receive(:execute).with(any_args).and_call_original
+      allow(@ci).to receive(:execute).with(chown_cmd).and_return(true)
     end
 
     after :each do
@@ -97,42 +108,34 @@ describe Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction do
                                    )
       end
 
-      it "fails when yum OS/REL/ARCH dir does not exist" do
+      it 'fails when yum OS/REL/ARCH dir does not exist' do
         @ci.apply
         expect( @ci.applied_status ).to eq(:failed)
         expect( @ci.apply_summary ).to eq 'Setup of local system (OS) YUM repositories for SIMP failed'
       end
 
-      it "fails when yum OS/REL/ARCH dir cannot be accessed" do
+      it 'fails when yum OS/REL/ARCH dir cannot be accessed' do
         FileUtils.mkdir_p @yum_dist_dir
         FileUtils.chmod 0444, @yum_dist_dir
         @ci.apply
         expect( @ci.applied_status ).to eq(:failed)
       end
 
-      it "fails when yum Updates dir cannot be created due to permissions" do
+      it 'fails when yum Updates dir cannot be created due to permissions' do
         FileUtils.mkdir_p @yum_dist_dir
         FileUtils.chmod 0555, @yum_dist_dir
         @ci.apply
         expect( @ci.applied_status ).to eq(:failed)
       end
 
-      it "fails when yum Updates dir cannot be created because a file named Updates exists" do
+      it 'fails when yum Updates dir cannot be created because a file named Updates exists' do
         FileUtils.mkdir_p @yum_dist_dir
         FileUtils.touch File.join(@yum_dist_dir, 'Updates')
         @ci.apply
         expect( @ci.applied_status ).to eq(:failed)
       end
 
-      it "fails when yum Updates dir cannot be accessed" do
-        updates_dir = File.join(@yum_dist_dir, 'Updates')
-        FileUtils.mkdir_p updates_dir
-        FileUtils.chmod 0000, updates_dir
-        @ci.apply
-        expect( @ci.applied_status ).to eq(:failed)
-      end
-
-      it "fails when yum.repos.d does not exist" do
+      it 'fails when yum.repos.d does not exist' do
         FileUtils.mkdir_p @yum_dist_dir
         FileUtils.rm_rf @tmp_repos_d
         @ci.apply
@@ -140,14 +143,7 @@ describe Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction do
         expect( @ci.apply_summary ).to eq 'Setup of local system (OS) YUM repositories for SIMP failed'
       end
 
-      it "fails when yum.repos.d cannot be accessed" do
-        FileUtils.mkdir_p @yum_dist_dir
-        FileUtils.chmod 0000, @tmp_repos_d
-        @ci.apply
-        expect( @ci.applied_status ).to eq(:failed)
-      end
-
-      it "fails when yum.repos.d is not a directory" do
+      it 'fails when yum.repos.d is not a directory' do
         FileUtils.mkdir_p @yum_dist_dir
         FileUtils.rm_rf @tmp_repos_d
         FileUtils.touch File.join(@tmp_dir, 'yum.repos.d')
@@ -174,7 +170,7 @@ describe Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction do
     end
   end
 
-  describe "#apply_summary" do
+  describe '#apply_summary' do
     it 'reports unattempted status when #apply not called' do
       ci = Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction.new
       expect( ci.apply_summary ).to eq 'Setup of local system (OS) YUM repositories for SIMP unattempted'

--- a/spec/lib/simp/cli/config/items/data/sssd_domains_spec.rb
+++ b/spec/lib/simp/cli/config/items/data/sssd_domains_spec.rb
@@ -8,20 +8,43 @@ describe Simp::Cli::Config::Item::SssdDomains do
     @ci.silent = true
   end
 
-  describe "#recommended_value" do
-    it "when `simp_options::ldap` is `true`" do
-      item = Simp::Cli::Config::Item::SimpOptionsLdap.new
-      item.value = true
-      @ci.config_items[item.key] = item
-      expect( @ci.recommended_value ).to eq ['LDAP']
+  describe '#recommended_value' do
+
+    context "when 'simp_options::ldap' is 'true'" do
+      it "should return ['LDAP']" do
+        item = Simp::Cli::Config::Item::SimpOptionsLdap.new
+          item.value = true
+        @ci.config_items[item.key] = item
+        expect( @ci.recommended_value ).to eq ['LDAP']
+      end
     end
 
-    it "when `simp_options::ldap` is `false`" do
-      item = Simp::Cli::Config::Item::SimpOptionsLdap.new
-      item.value = false
-      @ci.config_items[item.key] = item
-      expect( @ci.recommended_value ).to eq ['Local']
+    context "when 'simp_options::ldap' is 'false'" do
+      context 'OS major version < 8' do
+        it "should return ['LOCAL']" do
+          os_fact = { 'release' => { 'major' => '7' } }
+          allow(Facter).to receive(:value).with('os').and_return(os_fact)
+
+          item = Simp::Cli::Config::Item::SimpOptionsLdap.new
+          item.value = false
+          @ci.config_items[item.key] = item
+          expect( @ci.recommended_value ).to eq ['LOCAL']
+        end
+      end
+
+      context 'OS major version >= 8' do
+        it "should return []" do
+          os_fact = { 'release' => { 'major' => '8' } }
+          allow(Facter).to receive(:value).with('os').and_return(os_fact)
+
+          item = Simp::Cli::Config::Item::SimpOptionsLdap.new
+          item.value = false
+          @ci.config_items[item.key] = item
+          expect( @ci.recommended_value ).to eq []
+        end
+      end
     end
+
   end
 
   it_behaves_like "a child of Simp::Cli::Config::Item"

--- a/spec/lib/simp/cli/config/simp_puppet_env_helper_spec.rb
+++ b/spec/lib/simp/cli/config/simp_puppet_env_helper_spec.rb
@@ -83,27 +83,8 @@ describe Simp::Cli::Config::SimpPuppetEnvHelper do
   describe '#create' do
     # FIXME Need to mock module repos, env skeletons, etc. for OmniEnvController
     #       to do its work, or test this via 'simp config' in an acceptance test
-    pending 'should return new env info after create' do
-      allow(@env_helper).to receive(:get_system_puppet_info).and_return(@system_puppet_info)
-
-      expect( @env_helper.env_status[0] ).to eq :creatable
-
-      env_info = @env_helper.create
-
-      expected = {
-        :puppet_config      => @system_puppet_info[:config],
-        :puppet_group       => 'puppet',
-        :puppet_version     => '5.5.10',
-        :puppet_env         => 'production',
-        :puppet_env_dir     => @puppet_env_dir,
-        :puppet_env_datadir => @puppet_env_datadir, # should be now set instead of nil
-        :secondary_env_dir  => @secondary_env_dir,
-        :writable_env_dir   => @writable_env_dir
-      }
-
-      expect( env_info ).to eq expected
-
-      expect( @env_helper.env_status[0] ).to eq :exists
+    it 'should return new env info after create' do
+      skip('Tested in simp-core acceptance tests')
     end
 
     it 'should backup existing Puppet environment' do


### PR DESCRIPTION
- Fixed a bug where 'simp config' recommended the wrong SSSD domain,
  when the SIMP server was not the LDAP server.  It recommended the
  'Local' domain, when the appropriate SIMP-created domain with the
  'local' (EL6) or 'files' (EL7) provider is 'LOCAL'.
- Fixed bad changelog entry.
- Cleaned up a few unit tests
  - Mocked out a `hostname` system call in a spec test, instead of
    expecting the actual `hostname` operation to fail.
  - Mocked out File.exist?('/etc/yum.repos.d/simp_filesystem.repo')
    calls instead of assuming it will always return false.
  - Mocked out 'chown -R root:apache ...' system calls in spec tests.
  - Removed extraneous tests that were failing because of
    'chown -R root:apache' failures, instead of what the test was
    hoping to test. I didn't bother to fix the tests with mock behavior,
    because the error paths were adequately tested in other tests.
  - Skip a test that was marked pending but still attempted to execute
    actions on the local system.
- Set ssh keepalive settings in acceptance tests, to attempt
  to solve random ssh connection closures on slow GitLab servers.
- Unpinned version of beaker, as desired capabilities have now
  been released.

SIMP-8383 #close