### PR TITLE
(SIMP-8802) Remove Travis CI tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,6 +31,8 @@ variables:
   BUNDLE_BIN:        .vendor/gem_install/bin
   BUNDLE_NO_PRUNE:   'true'
 
+  SIMP_SKIP_NON_SIMPOS_TESTS: 1
+
 
 # bundler dependencies and caching
 #
@@ -122,8 +124,8 @@ sanity_checks:
   stage: 'sanity'
   tags: ['docker']
   script:
-    - 'if `hash apt-get`; then apt-get update; fi'
-    - 'if `hash apt-get`; then apt-get install -y rpm; fi'
+    - 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'
+    - 'command -v rpm || { >&2 echo "FATAL: Cannot find executable: ''rpm''";  exit 1 ;}'
     - 'bundle exec rake pkg:check_version'
     - 'bundle exec rake pkg:compare_latest_tag'
     - 'bundle exec rake pkg:create_tag_changelog'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,7 +13,6 @@
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
 ---
 stages:
-  - 'sanity'
   - 'validation'
   - 'acceptance'
   - 'compliance'
@@ -118,10 +117,10 @@ variables:
 # Pipeline / testing matrix
 #=======================================================================
 
-sanity_checks:
+releng_checks:
   <<: *pup_5
   <<: *setup_bundler_env
-  stage: 'sanity'
+  stage: 'validation'
   tags: ['docker']
   script:
     - 'command -v rpm || if command -v apt-get; then apt-get update; apt-get install -y rpm; fi ||:'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,32 +29,38 @@ before_install:
 
 jobs:
   include:
-    - stage: check
-      name: 'Syntax, style, and validation checks'
-      rvm: 2.4.9
-      script:
-        - bundle exec rake pkg:compare_latest_tag
-        - bundle exec rake pkg:create_tag_changelog
-        - bundle exec rake pkg:gem
+    ###  Testing on Travis CI is indefinitely disabled
+    ###
+    ###  See:
+    ###    * https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+    ###    * https://simp-project.atlassian.net/browse/SIMP-8703
+    ###
+    ###  - stage: check
+    ###    name: 'Syntax, style, and validation checks'
+    ###    rvm: 2.4.9
+    ###    script:
+    ###      - bundle exec rake pkg:compare_latest_tag
+    ###      - bundle exec rake pkg:create_tag_changelog
+    ###      - bundle exec rake pkg:gem
 
-    # Test with Ruby versions packaged with standard Puppet All-in-one installs
-    - stage: spec
-      name: 'Ruby packaged with Puppet 5.x'
-      rvm: 2.4.9
-      env:
-        - PUPPET_VERSION="~> 5.5"
-        - SIMP_SKIP_NON_SIMPOS_TESTS=1
-      script:
-        - bundle exec rake spec
+    ###  # Test with Ruby versions packaged with standard Puppet All-in-one installs
+    ###  - stage: spec
+    ###    name: 'Ruby packaged with Puppet 5.x'
+    ###    rvm: 2.4.9
+    ###    env:
+    ###      - PUPPET_VERSION="~> 5.5"
+    ###      - SIMP_SKIP_NON_SIMPOS_TESTS=1
+    ###    script:
+    ###      - bundle exec rake spec
 
-    - stage: spec
-      name: 'Ruby packaged with Puppet 6.x'
-      rvm: 2.5.8
-      env:
-        - PUPPET_VERSION="~> 6.0"
-        - SIMP_SKIP_NON_SIMPOS_TESTS=1
-      script:
-        - bundle exec rake spec
+    ###  - stage: spec
+    ###    name: 'Ruby packaged with Puppet 6.x'
+    ###    rvm: 2.5.8
+    ###    env:
+    ###      - PUPPET_VERSION="~> 6.0"
+    ###      - SIMP_SKIP_NON_SIMPOS_TESTS=1
+    ###    script:
+    ###     - bundle exec rake spec
 
     - stage: deploy
       rvm: 2.4.9

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'bundler'
 gem 'facter'
 gem 'highline', :path => 'ext/gems/highline'
 gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~>5')
-gem 'rake'
+gem 'rake', '>= 12.3.3'
 gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.6', '< 6.0'])
 
 gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.18.7', '< 2']

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 6.1.1
+%global cli_version 6.1.2
 %global highline_version 2.0.3
 
 # gem2ruby's method of installing gems into mocked build roots will blow up
@@ -129,6 +129,9 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Tue Dec 10 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.1.2
+- Bumped .gemspec dependencies to mitigate CVE-2020-8130
+
 * Thu Oct 15 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.1
 - Change the local user lockout warning to have simpler instructions
 

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '6.1.1'
+  VERSION = '6.1.2'
 end

--- a/simp-cli.gemspec
+++ b/simp-cli.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
   #### ------------
 
   # for development
-  s.add_development_dependency 'rake',        '~> 10'
+  s.add_development_dependency 'rake',        '>= 12.3.3'
   s.add_development_dependency 'rspec',       '~> 3'
   s.add_development_dependency 'rspec-its',   '~> 1'
   s.add_development_dependency 'listen',      '~> 3.0.0'


### PR DESCRIPTION
This patch removes ALL TESTS from the Travis CI pipeline.

It also updates the .gemspec to mitigate CVE-2020-8130.

[SIMP-8802] #close

[SIMP-8802]: https://simp-project.atlassian.net/browse/SIMP-8802