### PR TITLE
(SIMP-9378) simp-cli: allow empty domain list EL8

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -95,7 +95,7 @@ jobs:
         # rsync in simp environment commands
       - run: |
           sudo apt-get update
-          sudo apt-get install -y rpm cracklib-runtime libicu-dev rsync'
+          sudo apt-get install -y rpm cracklib-runtime libicu-dev rsync
         # simp cli code fetches USER env variable.  In the docker container USER is
         # not available, but the process is running as root.
       - run: 'USER=root SIMP_SKIP_NON_SIMPOS_TESTS=1 bundle exec rake spec'

--- a/lib/simp/cli/config/items/data/sssd_domains.rb
+++ b/lib/simp/cli/config/items/data/sssd_domains.rb
@@ -18,6 +18,8 @@ module Simp::Cli::Config
 IMPORTANT: For EL < 8, this field *MUST* have a valid domain or the sssd
 service will fail to start.
 }
+
+      @allow_empty_list = (Facter.value('os')['release']['major'] > '7')
     end
 
     def get_recommended_value
@@ -29,7 +31,7 @@ service will fail to start.
         # of the domain setup in the `simp` module.
         ['LDAP']
       else
-        if Facter.value('os')['release']['major'] < "8"
+        if Facter.value('os')['release']['major'] < '8'
           ['LOCAL']
         else
           []

--- a/spec/acceptance/shared_examples/fixtures_move.rb
+++ b/spec/acceptance/shared_examples/fixtures_move.rb
@@ -18,12 +18,5 @@ shared_examples 'fixtures move' do |master|
       on(master, "mkdir -p #{fixtures_staging_dir}/modules")
       on(master, "mv #{fixtures_orig_dest}/* #{fixtures_staging_dir}/modules")
     end
-
-    it 'should recreate empty dirs removed from rsync skeleton by fixtures copy' do
-      # TODO: Replace simp-rsync-skeleton install with git clone instead?
-#FIXME remove this when EL6 is removed from simp-rsync-skeleton
-      on(master, "mkdir #{fixtures_staging_dir}/assets/rsync_data/rsync/RedHat/6/bind_dns/default/named/var/tmp")
-      on(master, "mkdir #{fixtures_staging_dir}/assets/rsync_data/rsync/RedHat/6/bind_dns/default/named/var/log")
-    end
   end
 end

--- a/spec/lib/simp/cli/config/items/data/sssd_domains_spec.rb
+++ b/spec/lib/simp/cli/config/items/data/sssd_domains_spec.rb
@@ -3,12 +3,11 @@ require 'rspec/its'
 require_relative '../spec_helper'
 
 describe Simp::Cli::Config::Item::SssdDomains do
-  before :each do
-    @ci = Simp::Cli::Config::Item::SssdDomains.new
-    @ci.silent = true
-  end
-
   describe '#recommended_value' do
+    before :each do
+      @ci = Simp::Cli::Config::Item::SssdDomains.new
+      @ci.silent = true
+    end
 
     context "when 'simp_options::ldap' is 'true'" do
       it "should return ['LDAP']" do
@@ -21,31 +20,79 @@ describe Simp::Cli::Config::Item::SssdDomains do
 
     context "when 'simp_options::ldap' is 'false'" do
       context 'OS major version < 8' do
-        it "should return ['LOCAL']" do
+        before :each do
           os_fact = { 'release' => { 'major' => '7' } }
           allow(Facter).to receive(:value).with('os').and_return(os_fact)
 
           item = Simp::Cli::Config::Item::SimpOptionsLdap.new
           item.value = false
           @ci.config_items[item.key] = item
+        end
+
+        it "should return ['LOCAL']" do
           expect( @ci.recommended_value ).to eq ['LOCAL']
         end
       end
 
       context 'OS major version >= 8' do
-        it "should return []" do
+        before :each do
           os_fact = { 'release' => { 'major' => '8' } }
           allow(Facter).to receive(:value).with('os').and_return(os_fact)
 
           item = Simp::Cli::Config::Item::SimpOptionsLdap.new
           item.value = false
           @ci.config_items[item.key] = item
+        end
+
+        it 'should return []' do
           expect( @ci.recommended_value ).to eq []
         end
       end
     end
-
   end
 
-  it_behaves_like "a child of Simp::Cli::Config::Item"
+  describe '#validate' do
+    context 'OS major version < 8' do
+      before :each do
+        os_fact = { 'release' => { 'major' => '7' } }
+        allow(Facter).to receive(:value).with('os').and_return(os_fact)
+
+        @ci = Simp::Cli::Config::Item::SssdDomains.new
+        @ci.silent = true
+        item = Simp::Cli::Config::Item::SimpOptionsLdap.new
+        item.value = false
+        @ci.config_items[item.key] = item
+      end
+
+      it 'should reject an empty domain list' do
+        expect( @ci.validate([]) ).to eq false
+      end
+    end
+
+    context 'OS major version >= 8' do
+      before :each do
+        os_fact = { 'release' => { 'major' => '8' } }
+        allow(Facter).to receive(:value).with('os').and_return(os_fact)
+
+        @ci = Simp::Cli::Config::Item::SssdDomains.new
+        @ci.silent = true
+        item = Simp::Cli::Config::Item::SimpOptionsLdap.new
+        item.value = false
+        @ci.config_items[item.key] = item
+      end
+
+      it 'should accept an empty domain list' do
+        expect( @ci.validate([]) ).to eq true
+      end
+    end
+  end
+
+  context 'base operation' do
+    before :each do
+      @ci = Simp::Cli::Config::Item::SssdDomains.new
+      @ci.silent = true
+    end
+
+    it_behaves_like "a child of Simp::Cli::Config::Item"
+  end
 end


### PR DESCRIPTION
- Fixed a bug where sssd::domains validation did not allow an
  empty domain list in EL8, even though it recommended an empty
  domain list.
- Removed EL6-specific test logic that no longer applies, as
  simp-rsync-skeleton no longer installs those directories.

SIMP-9378 #close