### PR TITLE
(SIMP-7465) Update to handle chronyd default

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -124,18 +124,24 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
-* Tue Feb 09 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.2
-- The chrony module is not owned by simp and does not use simp_options
-  for default values.  `simp config` was updated to add a link from
-  chronyd::servers to simp_options::ntp::servers in hiera data so
-  default ntp servers are set for both ntpd and chronyd.
-- Updated  `simp config` to check for chronyd settings when determining
-  the OS defaults for simp_options::ntp::server
+* Tue Feb 09 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.2.0
+- simp config changes:
+  - Configure simp_options::ntp::servers instead of deprecated
+    simp_options::ntpd::servers.
+  - Set the NTP server defaults for ntpd and chronyd.
+    simp_options::ntp::servers is intended to be the default NTP server
+    settings for a SIMP system, regardless of whether it uses ntpd or
+    chronyd. However, the chrony module does not use simp_options,
+    because it is not a SIMP-maintained module. To work around this,
+    `simp config` was updated to set chrony::servers to an alias of
+    simp_options::ntp::servers in hieradata.
+  - Check for both ntpd and chronyd settings when determining the OS defaults
+    for simp_options::ntp::server, not just ntpd settings.
 
-* Mon Jan 11 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.2
+* Mon Jan 11 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 6.2.0
 - Remove support for EL6
 
-* Thu Dec 10 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.1.2
+* Thu Dec 10 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.2.0
 - Bumped .gemspec dependencies to mitigate CVE-2020-8130
 
 * Thu Oct 15 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 6.1.1

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -124,6 +124,14 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Tue Feb 09 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 6.1.2
+- The chrony module is not owned by simp and does not use simp_options
+  for default values.  `simp config` was updated to add a link from
+  chronyd::servers to simp_options::ntp::servers in hiera data so
+  default ntp servers are set for both ntpd and chronyd.
+- Updated  `simp config` to check for chronyd settings when determining
+  the OS defaults for simp_options::ntp::server
+
 * Mon Jan 11 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.2
 - Remove support for EL6
 
@@ -144,7 +152,7 @@ EOM
     dependencies for the sample Puppet code.
   - Tell the user to check that they can ssh into the server with the new
     user after bootstrap but before rebooting. This step is imperative to
-    ensure that the user can also get through Puppet-managed 
+    ensure that the user can also get through Puppet-managed
     authentication!
 - Fixed the following:
   - Bug in which `simp config` did not allow DNS domains that did

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -2,7 +2,7 @@
 
 %global gemdir /usr/share/simp/ruby
 %global geminstdir %{gemdir}/gems/%{gemname}-%{version}
-%global cli_version 6.1.2
+%global cli_version 6.2.0
 %global highline_version 2.0.3
 
 # gem2ruby's method of installing gems into mocked build roots will blow up

--- a/lib/simp/cli/config/items/data/chrony_servers.rb
+++ b/lib/simp/cli/config/items/data/chrony_servers.rb
@@ -5,18 +5,19 @@ require_relative 'cli_network_gateway'
 module Simp; end
 class Simp::Cli; end
 module Simp::Cli::Config
-  class Item::ChronydNTPServersDefault < Item
+  class Item::ChronyServers < Item
     def initialize(puppet_env_info = DEFAULT_PUPPET_ENV_INFO)
       super(puppet_env_info)
-      @key          = 'chronyd::servers'
-      @description  =  %Q{Chrony module is not a simp module and does not default to simp_options values.  This setting links chronyd server settings to simp_options::ntp::server}
-      @skip_query   = true
+      @key          = 'chrony::servers'
+      @description  =  'NTP time servers used by cronyd'
+      @skip_query   = true # default value is correct, so no query required
       @silent       = true
     end
 
     def validate(x)
       true
     end
+
     def get_recommended_value
       "%{alias('simp_options::ntp::servers')}"
     end

--- a/lib/simp/cli/config/items/data/chronyd_link_to_ntpservers.rb
+++ b/lib/simp/cli/config/items/data/chronyd_link_to_ntpservers.rb
@@ -18,7 +18,7 @@ module Simp::Cli::Config
       true
     end
     def get_recommended_value
-      "%{hiera('simp_options::ntp::servers')}"
+      "%{alias('simp_options::ntp::servers')}"
     end
 
   end

--- a/lib/simp/cli/config/items/data/chronyd_link_to_ntpservers.rb
+++ b/lib/simp/cli/config/items/data/chronyd_link_to_ntpservers.rb
@@ -1,0 +1,25 @@
+require_relative '../list_item'
+require_relative '../../utils'
+require_relative 'cli_network_gateway'
+
+module Simp; end
+class Simp::Cli; end
+module Simp::Cli::Config
+  class Item::ChronydNTPServersDefault < Item
+    def initialize(puppet_env_info = DEFAULT_PUPPET_ENV_INFO)
+      super(puppet_env_info)
+      @key          = 'chronyd::servers'
+      @description  =  %Q{Chrony module is not a simp module and does not default to simp_options values.  This setting links chronyd server settings to simp_options::ntp::server}
+      @skip_query   = true
+      @silent       = true
+    end
+
+    def validate(x)
+      true
+    end
+    def get_recommended_value
+      "%{hiera('simp_options::ntp::servers')}"
+    end
+
+  end
+end

--- a/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
@@ -8,7 +8,7 @@ module Simp::Cli::Config
   class Item::SimpOptionsNTPServers < ListItem
     def initialize(puppet_env_info = DEFAULT_PUPPET_ENV_INFO)
       super(puppet_env_info)
-      @key              = 'simp_options::ntpd::servers'
+      @key              = 'simp_options::ntp::servers'
       @description      =  %Q{Your network's NTP time servers.
 
 A consistent time source is critical to a functioning public key

--- a/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
@@ -29,9 +29,24 @@ negatively impact your site security. PKI depends upon sync'd time.]
       "#{@description}#{extra}"
     end
 
-    def get_os_value( file='/etc/ntp.conf' )
-      # TODO: make this a custom fact?
+    def get_systemctl_status(name)
+      system("systemctl status #{name} > /dev/null")
+      $?.exitstatus == 0
+    end
+
+    def get_os_value( chronydfile = '/etc/chrony.conf', ntpdfile = '/etc/ntp.conf' )
       servers = []
+      file = nil
+      if Simp::Cli::Utils.systemctl_running?('chronyd')
+        file = chronydfile
+      elsif Simp::Cli::Utils.systemctl_running?('ntpd')
+        file = ntpdfile
+      elsif File.exists?(chronydfile)
+        file = chronydfile
+      else
+        file = ntpdfile
+      end
+
       if File.readable? file
         File.readlines( file ).each do |line|
           match = line.match(/^server ([\w\.\-:]+)/)

--- a/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
+++ b/lib/simp/cli/config/items/data/simp_options_ntp_servers.rb
@@ -29,11 +29,6 @@ negatively impact your site security. PKI depends upon sync'd time.]
       "#{@description}#{extra}"
     end
 
-    def get_systemctl_status(name)
-      system("systemctl status #{name} > /dev/null")
-      $?.exitstatus == 0
-    end
-
     def get_os_value( chronydfile = '/etc/chrony.conf', ntpdfile = '/etc/ntp.conf' )
       servers = []
       file = nil

--- a/lib/simp/cli/config/scenarios/parts/network_setup
+++ b/lib/simp/cli/config/scenarios/parts/network_setup
@@ -30,4 +30,4 @@
     - SimpOptionsDNSSearch
 - SimpOptionsTrustedNets
 - SimpOptionsNTPServers
-- ChronydNTPServersDefault
+- ChronyServers              # never queries as default is correct

--- a/lib/simp/cli/config/scenarios/parts/network_setup
+++ b/lib/simp/cli/config/scenarios/parts/network_setup
@@ -30,3 +30,4 @@
     - SimpOptionsDNSSearch
 - SimpOptionsTrustedNets
 - SimpOptionsNTPServers
+- ChronydNTPServersDefault

--- a/lib/simp/cli/utils.rb
+++ b/lib/simp/cli/utils.rb
@@ -410,4 +410,9 @@ module Simp::Cli::Utils
     end
     result = (answer.downcase[0] == 'y')
   end
+
+  def systemctl_running?(name)
+    system("systemctl status #{name} > /dev/null")
+    $?.exitstatus == 0
+  end
 end

--- a/lib/simp/cli/utils.rb
+++ b/lib/simp/cli/utils.rb
@@ -411,8 +411,10 @@ module Simp::Cli::Utils
     result = (answer.downcase[0] == 'y')
   end
 
+  # @return whether a systemd service is running
+  # @param name Name of the systemd service
   def systemctl_running?(name)
-    system("systemctl status #{name} > /dev/null")
-    $?.exitstatus == 0
+    system("/usr/bin/systemctl status #{name} > /dev/null 2>&1")
+    $?.nil? ? false : ($?.exitstatus == 0)
   end
 end

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '6.1.2'
+  VERSION = '6.2.0'
 end

--- a/spec/lib/simp/cli/commands/config_run_spec.rb
+++ b/spec/lib/simp/cli/commands/config_run_spec.rb
@@ -754,7 +754,7 @@ describe 'Simp::Cli::Command::Config#run' do
           'simp_options::dns::servers=1.2.3.10',
           'simp_options::dns::search=test.local',
           'simp_options::trusted_nets=1.2.3.0/24',
-          'simp_options::ntpd::servers=time-a.nist.gov',
+          'simp_options::ntp::servers=time-a.nist.gov',
           'cli::set_grub_password=false',
           'puppetdb::master::config::puppetdb_port=0'])
 

--- a/spec/lib/simp/cli/commands/config_spec_helper.rb
+++ b/spec/lib/simp/cli/commands/config_spec_helper.rb
@@ -102,7 +102,7 @@ def config_normalize(file, other_keys_to_exclude = [], overrides = {})
      'grub::password',                     # hash value that varies from run-to-run with same password
      'simp_options::ldap::bind_hash',      # hash value that varies from run-to-run with same password
      'simp_options::ldap::sync_hash',      # hash value that varies from run-to-run with same password
-     'simp_options::ntpd::servers',        # depends upon actual system configuration
+     'simp_options::ntp::servers',         # depends upon actual system configuration
      'simp_openldap::server::conf::rootpw' # hash value that varies from run-to-run with same password
   ]
 

--- a/spec/lib/simp/cli/commands/files/incomplete_prev_simp_conf.yaml
+++ b/spec/lib/simp/cli/commands/files/incomplete_prev_simp_conf.yaml
@@ -29,7 +29,7 @@ simp_options::ldap::bind_hash: "{SSHA}tx9ennniDQnmx83gPjCqhy6pknR89QsD"
 simp_options::ldap::bind_pw: "vsB2myX+l8-p-FOmbjG%%Exr0R3z8Mkm"
 simp_options::ldap::sync_hash: "{SSHA}hdk9CtgE0+OMJ1xMVLJQrVTVzbsSwdku"
 simp_options::ldap::sync_pw: "6Pe4*3oW0Rw.VXx2Bbdv!nU2bv9x*%CB"
-simp_options::ntpd::servers: []
+simp_options::ntp::servers: []
 simp_options::puppet::ca: puppet.test.local
 simp_options::puppet::ca_port: 8141
 simp_options::puppet::server: puppet.test.local

--- a/spec/lib/simp/cli/commands/files/prev_simp_conf.yaml
+++ b/spec/lib/simp/cli/commands/files/prev_simp_conf.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
+chronyd::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: true
 cli::network::dhcp: static
 cli::network::gateway: "1.2.3.1"

--- a/spec/lib/simp/cli/commands/files/prev_simp_conf.yaml
+++ b/spec/lib/simp/cli/commands/files/prev_simp_conf.yaml
@@ -1,4 +1,5 @@
 ---
+chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: true
 cli::network::dhcp: static
 cli::network::gateway: "1.2.3.1"

--- a/spec/lib/simp/cli/commands/files/prev_simp_conf.yaml
+++ b/spec/lib/simp/cli/commands/files/prev_simp_conf.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{alias('simp_options::ntp::servers')}"
+chrony::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: true
 cli::network::dhcp: static
 cli::network::gateway: "1.2.3.1"
@@ -29,7 +29,7 @@ simp_options::ldap::bind_hash: "{SSHA}tx9ennniDQnmx83gPjCqhy6pknR89QsD"
 simp_options::ldap::bind_pw: "vsB2myX+l8-p-FOmbjG%%Exr0R3z8Mkm"
 simp_options::ldap::sync_hash: "{SSHA}hdk9CtgE0+OMJ1xMVLJQrVTVzbsSwdku"
 simp_options::ldap::sync_pw: "6Pe4*3oW0Rw.VXx2Bbdv!nU2bv9x*%CB"
-simp_options::ntpd::servers: []
+simp_options::ntp::servers: []
 simp_options::puppet::ca: puppet.test.local
 simp_options::puppet::ca_port: 8141
 simp_options::puppet::server: puppet.test.local

--- a/spec/lib/simp/cli/commands/files/prev_simp_conf_invalid_interface.yaml
+++ b/spec/lib/simp/cli/commands/files/prev_simp_conf_invalid_interface.yaml
@@ -28,7 +28,7 @@ simp_options::ldap::bind_hash: "{SSHA}tx9ennniDQnmx83gPjCqhy6pknR89QsD"
 simp_options::ldap::bind_pw: "vsB2myX+l8-p-FOmbjG%%Exr0R3z8Mkm"
 simp_options::ldap::sync_hash: "{SSHA}hdk9CtgE0+OMJ1xMVLJQrVTVzbsSwdku"
 simp_options::ldap::sync_pw: "6Pe4*3oW0Rw.VXx2Bbdv!nU2bv9x*%CB"
-simp_options::ntpd::servers: []
+simp_options::ntp::servers: []
 simp_options::puppet::ca: puppet.test.local
 simp_options::puppet::ca_port: 8141
 simp_options::puppet::server: puppet.test.local

--- a/spec/lib/simp/cli/commands/files/simp_conf_accepting_defaults_simp_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_accepting_defaults_simp_scenario.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
+chronyd::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: true
 cli::network::dhcp: static
 cli::network::gateway: "1.2.3.1"

--- a/spec/lib/simp/cli/commands/files/simp_conf_accepting_defaults_simp_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_accepting_defaults_simp_scenario.yaml
@@ -1,4 +1,5 @@
 ---
+chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: true
 cli::network::dhcp: static
 cli::network::gateway: "1.2.3.1"

--- a/spec/lib/simp/cli/commands/files/simp_conf_accepting_defaults_simp_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_accepting_defaults_simp_scenario.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{alias('simp_options::ntp::servers')}"
+chrony::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: true
 cli::network::dhcp: static
 cli::network::gateway: "1.2.3.1"
@@ -29,7 +29,7 @@ simp_options::ldap::bind_hash: "{SSHA}tx9ennniDQnmx83gPjCqhy6pknR89QsD"
 simp_options::ldap::bind_pw: "vsB2myX+l8-p-FOmbjG%%Exr0R3z8Mkm"
 simp_options::ldap::sync_hash: "{SSHA}hdk9CtgE0+OMJ1xMVLJQrVTVzbsSwdku"
 simp_options::ldap::sync_pw: "6Pe4*3oW0Rw.VXx2Bbdv!nU2bv9x*%CB"
-simp_options::ntpd::servers: []
+simp_options::ntp::servers: []
 simp_options::puppet::ca: puppet.test.local
 simp_options::puppet::ca_port: 8141
 simp_options::puppet::server: puppet.test.local

--- a/spec/lib/simp/cli/commands/files/simp_conf_missing_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_missing_scenario.yaml
@@ -26,7 +26,7 @@ simp_options::ldap::bind_hash: "{SSHA}tx9ennniDQnmx83gPjCqhy6pknR89QsD"
 simp_options::ldap::bind_pw: "vsB2myX+l8-p-FOmbjG%%Exr0R3z8Mkm"
 simp_options::ldap::sync_hash: "{SSHA}hdk9CtgE0+OMJ1xMVLJQrVTVzbsSwdku"
 simp_options::ldap::sync_pw: "6Pe4*3oW0Rw.VXx2Bbdv!nU2bv9x*%CB"
-simp_options::ntpd::servers: []
+simp_options::ntp::servers: []
 simp_options::puppet::ca: puppet.test.local
 simp_options::puppet::ca_port: 8141
 simp_options::puppet::server: puppet.test.local

--- a/spec/lib/simp/cli/commands/files/simp_conf_setting_values_poss_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_setting_values_poss_scenario.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{alias('simp_options::ntp::servers')}"
+chrony::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: false
 cli::network::gateway: "1.2.3.1"
 cli::network::hostname: simp.test.local
@@ -20,7 +20,7 @@ simp_options::dns::search:
 simp_options::dns::servers:
   - "1.2.3.10"
 simp_options::fips: true
-simp_options::ntpd::servers:
+simp_options::ntp::servers:
   - time-a.nist.gov
 simp_options::puppet::ca: simp.test.local
 simp_options::puppet::ca_port: 8141

--- a/spec/lib/simp/cli/commands/files/simp_conf_setting_values_poss_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_setting_values_poss_scenario.yaml
@@ -1,4 +1,5 @@
 ---
+chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: false
 cli::network::gateway: "1.2.3.1"
 cli::network::hostname: simp.test.local

--- a/spec/lib/simp/cli/commands/files/simp_conf_setting_values_poss_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_setting_values_poss_scenario.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
+chronyd::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: false
 cli::network::gateway: "1.2.3.1"
 cli::network::hostname: simp.test.local

--- a/spec/lib/simp/cli/commands/files/simp_conf_setting_values_simp_lite_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_setting_values_simp_lite_scenario.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{alias('simp_options::ntp::servers')}"
+chrony::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: false
 cli::network::gateway: "1.2.3.1"
 cli::network::hostname: simp.test.local
@@ -20,7 +20,7 @@ simp_options::dns::search:
 simp_options::dns::servers:
   - "1.2.3.10"
 simp_options::fips: true
-simp_options::ntpd::servers: [ "time-a.nist.gov" ]
+simp_options::ntp::servers: [ "time-a.nist.gov" ]
 simp_options::puppet::ca: simp.test.local
 simp_options::puppet::ca_port: 8141
 simp_options::puppet::server: simp.test.local

--- a/spec/lib/simp/cli/commands/files/simp_conf_setting_values_simp_lite_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_setting_values_simp_lite_scenario.yaml
@@ -1,4 +1,5 @@
 ---
+chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: false
 cli::network::gateway: "1.2.3.1"
 cli::network::hostname: simp.test.local

--- a/spec/lib/simp/cli/commands/files/simp_conf_setting_values_simp_lite_scenario.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_setting_values_simp_lite_scenario.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
+chronyd::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: false
 cli::network::gateway: "1.2.3.1"
 cli::network::hostname: simp.test.local

--- a/spec/lib/simp/cli/commands/files/simp_conf_with_overrides.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_with_overrides.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{alias('simp_options::ntp::servers')}"
+chrony::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: true
 cli::network::dhcp: static
 cli::network::gateway: "1.2.3.1"
@@ -31,7 +31,7 @@ simp_options::ldap::bind_hash: "{SSHA}tx9ennniDQnmx83gPjCqhy6pknR89QsD"
 simp_options::ldap::bind_pw: "vsB2myX+l8-p-FOmbjG%%Exr0R3z8Mkm"
 simp_options::ldap::sync_hash: "{SSHA}hdk9CtgE0+OMJ1xMVLJQrVTVzbsSwdku"
 simp_options::ldap::sync_pw: "6Pe4*3oW0Rw.VXx2Bbdv!nU2bv9x*%CB"
-simp_options::ntpd::servers: []
+simp_options::ntp::servers: []
 simp_options::puppet::ca: puppet.test.local
 simp_options::puppet::ca_port: 8141
 simp_options::puppet::server: puppet.test.local

--- a/spec/lib/simp/cli/commands/files/simp_conf_with_overrides.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_with_overrides.yaml
@@ -1,5 +1,5 @@
 ---
-chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
+chronyd::servers: "%{alias('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: true
 cli::network::dhcp: static
 cli::network::gateway: "1.2.3.1"

--- a/spec/lib/simp/cli/commands/files/simp_conf_with_overrides.yaml
+++ b/spec/lib/simp/cli/commands/files/simp_conf_with_overrides.yaml
@@ -1,4 +1,5 @@
 ---
+chronyd::servers: "%{hiera('simp_options::ntp::servers')}"
 cli::is_simp_ldap_server: true
 cli::network::dhcp: static
 cli::network::gateway: "1.2.3.1"

--- a/spec/lib/simp/cli/config/files/poss_generated_items_tree.yaml
+++ b/spec/lib/simp/cli/config/files/poss_generated_items_tree.yaml
@@ -39,6 +39,7 @@
     - SimpOptionsDNSSearch
 - SimpOptionsTrustedNets
 - SimpOptionsNTPServers
+- ChronydNTPServersDefault
 
 # ==== General server setup actions and related configuration ====
 - CliSetGrubPassword:

--- a/spec/lib/simp/cli/config/files/poss_generated_items_tree.yaml
+++ b/spec/lib/simp/cli/config/files/poss_generated_items_tree.yaml
@@ -39,7 +39,7 @@
     - SimpOptionsDNSSearch
 - SimpOptionsTrustedNets
 - SimpOptionsNTPServers
-- ChronydNTPServersDefault
+- ChronyServers              # never queries as default is correct
 
 # ==== General server setup actions and related configuration ====
 - CliSetGrubPassword:

--- a/spec/lib/simp/cli/config/files/simp_generated_items_tree.yaml
+++ b/spec/lib/simp/cli/config/files/simp_generated_items_tree.yaml
@@ -39,6 +39,7 @@
     - SimpOptionsDNSSearch
 - SimpOptionsTrustedNets
 - SimpOptionsNTPServers
+- ChronydNTPServersDefault
 
 # ==== General server setup actions and related configuration ====
 - CliSetGrubPassword:

--- a/spec/lib/simp/cli/config/files/simp_generated_items_tree.yaml
+++ b/spec/lib/simp/cli/config/files/simp_generated_items_tree.yaml
@@ -39,7 +39,7 @@
     - SimpOptionsDNSSearch
 - SimpOptionsTrustedNets
 - SimpOptionsNTPServers
-- ChronydNTPServersDefault
+- ChronyServers              # never queries as default is correct
 
 # ==== General server setup actions and related configuration ====
 - CliSetGrubPassword:

--- a/spec/lib/simp/cli/config/files/simp_lite_generated_items_tree.yaml
+++ b/spec/lib/simp/cli/config/files/simp_lite_generated_items_tree.yaml
@@ -39,6 +39,7 @@
     - SimpOptionsDNSSearch
 - SimpOptionsTrustedNets
 - SimpOptionsNTPServers
+- ChronydNTPServersDefault
 
 # ==== General server setup actions and related configuration ====
 - CliSetGrubPassword:

--- a/spec/lib/simp/cli/config/files/simp_lite_generated_items_tree.yaml
+++ b/spec/lib/simp/cli/config/files/simp_lite_generated_items_tree.yaml
@@ -39,7 +39,7 @@
     - SimpOptionsDNSSearch
 - SimpOptionsTrustedNets
 - SimpOptionsNTPServers
-- ChronydNTPServersDefault
+- ChronyServers              # never queries as default is correct
 
 # ==== General server setup actions and related configuration ====
 - CliSetGrubPassword:

--- a/spec/lib/simp/cli/config/items/data/files/chrony.conf_local_servers
+++ b/spec/lib/simp/cli/config/items/data/files/chrony.conf_local_servers
@@ -1,0 +1,37 @@
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 127.0.0.1 iburst
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking
+

--- a/spec/lib/simp/cli/config/items/data/files/chrony.conf_no_servers
+++ b/spec/lib/simp/cli/config/items/data/files/chrony.conf_no_servers
@@ -1,0 +1,36 @@
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking
+

--- a/spec/lib/simp/cli/config/items/data/files/chrony.conf_remote_servers
+++ b/spec/lib/simp/cli/config/items/data/files/chrony.conf_remote_servers
@@ -1,0 +1,38 @@
+
+# Use public servers from the pool.ntp.org project.
+# Please consider joining the pool (http://www.pool.ntp.org/join.html).
+server 0.chronyd.centos.pool.ntp.org iburst
+server 1.chronyd.centos.pool.ntp.org iburst
+
+# Record the rate at which the system clock gains/losses time.
+driftfile /var/lib/chrony/drift
+
+# Allow the system clock to be stepped in the first three updates
+# if its offset is larger than 1 second.
+makestep 1.0 3
+
+# Enable kernel synchronization of the real-time clock (RTC).
+rtcsync
+
+# Enable hardware timestamping on all interfaces that support it.
+#hwtimestamp *
+
+# Increase the minimum number of selectable sources required to adjust
+# the system clock.
+#minsources 2
+
+# Allow NTP client access from local network.
+#allow 192.168.0.0/16
+
+# Serve time even if not synchronized to a time source.
+#local stratum 10
+
+# Specify file containing keys for NTP authentication.
+#keyfile /etc/chrony.keys
+
+# Specify directory for log files.
+logdir /var/log/chrony
+
+# Select which information is logged.
+#log measurements statistics tracking
+

--- a/spec/lib/simp/cli/config/items/data/files/ntp.conf_remote_servers
+++ b/spec/lib/simp/cli/config/items/data/files/ntp.conf_remote_servers
@@ -10,10 +10,8 @@ server  127.127.1.0 # local clock
 fudge 127.127.1.0 stratum 10
 
 
-server 0.north-america.pool.ntp.org prefer burst
-server 1.north-america.pool.ntp.org burst
-server 2.north-america.pool.ntp.org
-server 3.north-america.pool.ntp.org
+server 0.ntpd.north-america.pool.ntp.org prefer burst
+server 1.ntpd.north-america.pool.ntp.org burst
 server 127.127.1.0
 driftfile /var/lib/ntp/drift
 broadcastdelay  0.004

--- a/spec/lib/simp/cli/config/items/data/simp_options_ntp_servers_spec.rb
+++ b/spec/lib/simp/cli/config/items/data/simp_options_ntp_servers_spec.rb
@@ -44,26 +44,70 @@ describe Simp::Cli::Config::Item::SimpOptionsNTPServers do
   end
 
   describe '#get_os_value' do
-    it 'returns empty array when ntp.conf is not accessible' do
-      expect( @ci.get_os_value('/does/not/exist') ).to eq []
+    before :all do
+      @ntp_no_servers = File.join(@files_dir,'ntp.conf_no_servers')
+      @chrony_no_servers = File.join(@files_dir,'chrony.conf_no_servers')
+      @chrony_remote_servers = File.join(@files_dir,'chrony.conf_remote_servers')
+      @ntp_remote_servers = File.join(@files_dir,'ntp.conf_remote_servers')
+      @chrony_local_servers = File.join(@files_dir,'chrony.conf_local_servers')
+      @ntp_local_servers = File.join(@files_dir,'ntp.conf_local_servers')
     end
 
-    it 'returns empty array when ntp.conf has no servers' do
-      expect( @ci.get_os_value(File.join(@files_dir,'ntp.conf_no_servers')) ).to eq []
+    it 'returns empty array when chrony.conf has no servers and chrondy is running' do
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('chronyd').and_return(true)
+      expect( @ci.get_os_value(@chrony_no_servers, @ntp_no_servers)).to eq []
     end
 
-    it 'returns empty array when ntp.conf has only local servers' do
-      expect( @ci.get_os_value(File.join(@files_dir,'ntp.conf_local_servers')) ).to eq []
+    it 'returns empty array when ntp.conf has no servers and ntp is running' do
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('ntpd').and_return(true)
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('chronyd').and_return(false)
+      expect( @ci.get_os_value(@chrony_no_servers, @ntp_no_servers)).to eq []
     end
 
-    it 'returns array of only remote servers when ntp.conf lists remote and local servers' do
+    it 'returns chrony servers when chrony is running' do
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('chronyd').and_return(true)
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('ntpd').and_return(true)
       expected = [
-        '0.north-america.pool.ntp.org',
-        '1.north-america.pool.ntp.org',
-        '2.north-america.pool.ntp.org',
-        '3.north-america.pool.ntp.org'
+        '0.chronyd.centos.pool.ntp.org',
+        '1.chronyd.centos.pool.ntp.org'
       ]
-      expect( @ci.get_os_value(File.join(@files_dir,'ntp.conf_remote_servers')) ).to eq expected
+      expect( @ci.get_os_value(@chrony_remote_servers,@ntp_remote_servers)).to eq expected
+    end
+
+    it 'returns ntpd servers when chrony is not running but ntpd is' do
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('chronyd').and_return(false)
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('ntpd').and_return(true)
+      expected = [
+        '0.ntpd.north-america.pool.ntp.org',
+        '1.ntpd.north-america.pool.ntp.org'
+      ]
+      expect( @ci.get_os_value(@chrony_remote_servers,@ntp_remote_servers)).to eq expected
+    end
+    it 'returns empty array when it can not access the files' do
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('chronyd').and_return(false)
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('ntpd').and_return(false)
+      expect( @ci.get_os_value('/not/there', '/not/there') ).to eq []
+    end
+
+    it 'returns empty array when local servers are in the chrony files' do
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('chronyd').and_return(false)
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('ntpd').and_return(false)
+      expect( @ci.get_os_value(@chrony_local_servers,@ntp_remote_servers)).to eq []
+    end
+
+    it 'returns empty array when local servers are in the ntps files' do
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('chronyd').and_return(false)
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('ntpd').and_return(true)
+      expect( @ci.get_os_value('/not/there',@ntp_local_servers)).to eq []
+    end
+    it 'returns the ntp servers when no services are running and not chrony file exists' do
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('chronyd').and_return(false)
+      allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('ntpd').and_return(false)
+      expected = [
+        '0.ntpd.north-america.pool.ntp.org',
+        '1.ntpd.north-america.pool.ntp.org'
+      ]
+      expect( @ci.get_os_value('/not/there',@ntp_remote_servers)).to eq expected
     end
   end
 

--- a/spec/lib/simp/cli/config/items/data/simp_options_ntp_servers_spec.rb
+++ b/spec/lib/simp/cli/config/items/data/simp_options_ntp_servers_spec.rb
@@ -100,7 +100,7 @@ describe Simp::Cli::Config::Item::SimpOptionsNTPServers do
       allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('ntpd').and_return(true)
       expect( @ci.get_os_value('/not/there',@ntp_local_servers)).to eq []
     end
-    it 'returns the ntp servers when no services are running and not chrony file exists' do
+    it 'returns the ntp servers when no services are running and no chrony file exists' do
       allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('chronyd').and_return(false)
       allow(Simp::Cli::Utils).to receive(:systemctl_running?).with('ntpd').and_return(false)
       expected = [


### PR DESCRIPTION
- Add item in network task list to create a hiera link from
  chronyd::servers to simp_options::ntp::servers.
- Update `simp config` to check for chrony settings
  when determining the currently set os value.

SIMP-7465 #close
SIMP-8966 #close