### PR TITLE
(SIMP-9621) simp cli tests fail on EL8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /.bundle
 /vendor
 Gemfile.lock
+spec/acceptance/suites/*/nodesets
 spec/lib/simp/cli/config/item/tmp/
 spec/fixtures
 .vagrant

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,12 +221,11 @@ pup6.x-fips:
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
-# SIMP-9621 Tests fail on centos8
-#pup6.x_centos8:
-#  <<: *pup_6_x
-#  <<: *acceptance_base
-#  script:
-#    - 'bundle exec rake beaker:suites[default,centos8]'
+pup6.x_centos8:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,centos8]'
 
 pup6.x_config:
   <<: *pup_6_x
@@ -240,12 +239,11 @@ pup6.x_config-fips:
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[config,default]'
 
-# SIMP-9621 Tests fail on centos8
-#pup6.x_config_centos8:
-#  <<: *pup_6_x
-#  <<: *acceptance_base
-#  script:
-#    - 'bundle exec rake beaker:suites[config,centos8]'
+pup6.x_config_centos8:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[config,centos8]'
 
 pup6.x_simp_kv:
   <<: *pup_6_x
@@ -260,9 +258,8 @@ pup6.x_simp_kv-fips:
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[simp_kv,default]'
 
-# SIMP-9621 Tests fail on centos8
-#pup6.x_simp_kv_centos8:
-#  <<: *pup_6_x
-#  <<: *acceptance_base
-#  script:
-#    - 'bundle exec rake beaker:suites[simp_kv,centos8]'
+pup6.x_simp_kv_centos8:
+  <<: *pup_6_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[simp_kv,centos8]'

--- a/lib/simp/cli/commands/bootstrap.rb
+++ b/lib/simp/cli/commands/bootstrap.rb
@@ -623,8 +623,8 @@ class Simp::Cli::Commands::Bootstrap < Simp::Cli::Commands::Command
       info("Checking if puppetserver is accepting connections on port #{port}", 'cyan')
     end
     curl_cmd = "curl -sS --cert #{Simp::Cli::Utils.puppet_info[:config]['hostcert']}" +
-        " --key #{Simp::Cli::Utils.puppet_info[:config]['hostprivkey']} -k -H" +
-        " \"Accept: s\" https://localhost:#{port}/production/certificate_revocation_list/ca"
+        " --key #{Simp::Cli::Utils.puppet_info[:config]['hostprivkey']} -k" +
+        " https://localhost:#{port}/production/certificate_revocation_list/ca"
     debug(curl_cmd) unless quiet
     running = (%x{#{curl_cmd} 2>&1} =~ /CRL/)
     running

--- a/lib/simp/cli/config/items/list_item.rb
+++ b/lib/simp/cli/config/items/list_item.rb
@@ -14,10 +14,11 @@ module Simp::Cli::Config
     end
 
     def default_value_noninteractive
-      if @value.nil? and @allow_empty_list
+      value = default_value
+      if value.nil? && @allow_empty_list
         return []
       else
-        return default_value
+        return value
       end
     end
 
@@ -30,8 +31,7 @@ module Simp::Cli::Config
       extra = "hit enter to accept default value" if default_value
       # Code actually allows comma and space delimited lists, but
       # a simpler instruction to the end user is best
-      instructions = "Enter a space-delimited list (#{extra})"
-      ::HighLine.color( instructions, ::HighLine.const_get('YELLOW') )
+      "Enter a space-delimited list (#{extra})".yellow
     end
 
     def query_extras( q )
@@ -54,9 +54,11 @@ module Simp::Cli::Config
 
     # validate the list and each item in the list
     def validate( list )
-      # reuse the highline lambda to sanitize input
       return true  if (@allow_empty_list && list.nil?)
+
+      # reuse the highline lambda to sanitize input
       list = highline_question_type.call( list ) if !list.is_a? Array
+
       return false if !list.is_a?(Array)
       return false if (!@allow_empty_list && list.empty? )
       list.each{ |item|
@@ -68,18 +70,6 @@ module Simp::Cli::Config
     # validate a single list item
     def validate_item( x )
       raise InternalError.new( "#{self.class}.validate_item() not implemented!" )
-    end
-
-    # print a pretty summary of the ListItem's key+value, printed to stdout
-    def print_summary
-      raise InternalError.new( "@key is empty for #{self.class}" ) if "#{@key}".empty?
-
-      if @value.nil?
-        final_value = []
-      else
-        final_value = @value
-      end
-      super
     end
   end
 end

--- a/spec/acceptance/shared_examples/configure_puppet_env.rb
+++ b/spec/acceptance/shared_examples/configure_puppet_env.rb
@@ -23,13 +23,11 @@ shared_examples 'configure puppet env' do |host,env|
     # wait for it to come up
     master_fqdn = fact_on(host, 'fqdn')
     puppetserver_status_cmd = [
-      'curl -sk',
+      'curl -sSk',
       "--cert /etc/puppetlabs/puppet/ssl/certs/#{master_fqdn}.pem",
       "--key /etc/puppetlabs/puppet/ssl/private_keys/#{master_fqdn}.pem",
-      "https://#{master_fqdn}:8140/status/v1/services",
-      '| python -m json.tool',
-      '| grep state',
-      '| grep running'
+      "https://localhost:8140/production/certificate_revocation_list/ca",
+      '| grep CRL'
     ].join(' ')
     retry_on(host, puppetserver_status_cmd, :retry_interval => 10)
   end

--- a/spec/lib/simp/cli/config/items/list_item_spec.rb
+++ b/spec/lib/simp/cli/config/items/list_item_spec.rb
@@ -7,16 +7,83 @@ describe Simp::Cli::Config::ListItem do
     @ci = Simp::Cli::Config::ListItem.new
   end
 
-  context "when @allow_empty_list = true" do
-    before :each do
-      @ci.allow_empty_list = false
-      @ci.value = []
+  describe 'constructor' do
+    it 'does not allow empty lists by default' do
+      expect(@ci.allow_empty_list).to be false
+    end
+  end
+
+  describe '#default_value_noninteractive' do
+    it 'returns [] when default_value()=nil and empty lists are allowed' do
+      #  @ci.default_value will return nil, because ListItem does not override
+      #  Item#get_recommended_value
+      @ci.allow_empty_list = true
+      expect( @ci.default_value_noninteractive ).to eq([])
     end
 
-    describe "#validate" do
-      it "doesn't validate an empty array" do
-        expect( @ci.validate [] ).to eq false
-      end
+    it 'returns nil when default_value()=nil and empty lists are not allowed' do
+      expect( @ci.default_value_noninteractive ).to be_nil
+    end
+
+    it 'returns default_value() otherwise' do
+      @ci.allow_empty_list = true
+      expect(@ci).to receive(:default_value).and_return(['default','array'])
+      expect( @ci.default_value_noninteractive ).to eq(['default','array'])
+    end
+  end
+
+  describe '#instructions' do
+    it "returns 'skip' instructions when default_value()=nil" do
+      instr = @ci.instructions
+      expect(instr).to match(/Enter a space-delimited list \(hit enter to skip\)/)
+    end
+
+    it "returns 'accept default value' instructions when default_value is set" do
+      expect(@ci).to receive(:default_value).and_return(['default','array'])
+      instr = @ci.instructions
+      expect(instr).to match(/Enter a space-delimited list \(hit enter to accept default value\)/)
+    end
+  end
+
+  describe '#highline_question_type' do
+    it 'converts a String with one values into an Array' do
+      list = @ci.highline_question_type.call('default')
+      expect(list).to eq(['default'])
+    end
+
+    it 'converts a String with multiple space-separated values into an Array' do
+      list = @ci.highline_question_type.call('default array')
+      expect(list).to eq(['default', 'array'])
+    end
+
+    it 'converts a String with multiple comma-separated values into an Array' do
+      list = @ci.highline_question_type.call('default,array')
+      expect(list).to eq(['default', 'array'])
+    end
+  end
+
+  describe '#validate' do
+    it 'returns true for nil value when empty lists are allowed' do
+      @ci.allow_empty_list = true
+      expect( @ci.validate(nil) ).to be true
+    end
+
+    it 'returns false for nil value when empty lists are not allowed' do
+      expect( @ci.validate(nil) ).to be false
+    end
+
+    it 'returns false for [] value when empty lists are not allowed' do
+      expect( @ci.validate([]) ).to be false
+    end
+
+    it 'returns false if any array item is invalid' do
+      expect(@ci).to receive(:validate_item).and_return(true,false)
+      expect( @ci.validate(['good1', 'bad', 'good2']) ).to be false
+    end
+
+    it 'returns true if all array items are valid' do
+      expect(@ci).to receive(:validate_item).and_return(true,true)
+      expect( @ci.validate(['good1', 'good2']) ).to be true
     end
   end
 end


### PR DESCRIPTION
- Fixed an internal simp config bug that was causing the non-interactive
  default value for sssd:domains to be incorrectly determined on EL8.
- Removed the OBE and ignored HTTP Accept header in the curl command used
  by `simp bootstrap` to determine if the puppetserver is up.
- Fixed the test command used to determine if the puppetserver was up.
  - The unversioned `python` command is not available on EL8. So,
    reworked the command to match that used by `simp bootstrap`.
- Re-enabled EL8 tests in GitLab.

SIMP-9621 #close