### PR TITLE
(SIMP-10255) rubygem-simp-cli Ensure testing with CentOS 8.4

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,23 +1,30 @@
+# ------------------------------------------------------------------------------
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
-# https://puppet.com/docs/pe/2021.1/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/2019.8/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
-# Release         Puppet   Ruby    EOL
-# SIMP 6.5        6.18     2.5.8
-# PE 2019.8.6     6.22.1   2.5.9   2022-12 (LTS)
+# Release       Puppet   Ruby    EOL
+# PE 2019.8     6.22     2.5.7   2022-12 (LTS)
 ---
 
 stages:
   - 'validation'
   - 'acceptance'
-  - 'compliance'
   - 'deployment'
 
 variables:
+  # PUPPET_VERSION is a canary variable!
+  #
+  # The value `UNDEFINED` will (intentionally) cause `bundler install|update` to
+  # fail.  The intended value for PUPPET_VERSION is provided by the `pup_#` YAML
+  # anchors.  If it is still `UNDEFINED`, all the other setting from the job's
+  # anchor are also missing.
   PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)
-  BUNDLER_VERSION:   '1.17.1'
+  BUNDLER_VERSION:   '2.2.19'
+  SIMP_MATRIX_LEVEL: '1'
+  SIMP_FORCE_RUN_MATRIX: 'no'
 
   # Force dependencies into a path the gitlab-runner user can write to.
   # (This avoids some failures on Runners with misconfigured ruby environments.)
@@ -27,9 +34,6 @@ variables:
   BUNDLE_BIN:        .vendor/gem_install/bin
   BUNDLE_NO_PRUNE:   'true'
 
-  SIMP_SKIP_NON_SIMPOS_TESTS: 1
-
-
 # bundler dependencies and caching
 #
 # - Cache bundler gems between pipelines foreach Ruby version
@@ -37,44 +41,170 @@ variables:
 # --------------------------------------
 .setup_bundler_env: &setup_bundler_env
   cache:
-    untracked: true
     key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
     paths:
       - '.vendor'
   before_script:
-    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX/); pad=e.map{|x| x.size}.max+1; e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)"'
+    # Print important environment variables that may affect this job
+    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX/); pad=((e.map{|x| x.size}.max||0)+1); e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)" || :'
+
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script10[collapsed=true]\r\e[0KDiagnostic ruby & gem information"
     # Diagnostic ruby & gem information
     - 'which ruby && ruby --version || :'
     - "[[ $- == *i* ]] && echo 'Interactive shell session' || echo 'Non-interactive shell session'"
     - "shopt -q login_shell && echo 'Login shell' || echo 'Not a login shell'"
     - 'rvm ls || :'
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script10\r\e[0K"
 
     # If RVM is available, make SURE it's using the right Ruby:
     #   * Source rvm (to run in non-login shells)
-    #   * If any $MATRIX_RUBY_VERSION rubies are available, use the latest
-    #   * Otherwise: install & use ${MATRIX_RUBY_VERSION}-head (e.g., latest)
-    #     * ^^ This could be wonky and introduce variations across runners
-    #     * ^^ maybe it should just fail if there is no $MATRIX_RUBY_VERSION installed?
-    - "command -v rvm && { if declare -p rvm_path &> /dev/null; then source \"${rvm_path}/scripts/rvm\"; else source \"$HOME/.rvm/scripts/rvm\" || source /etc/profile.d/rvm.sh; fi; }"
-    - "command -v rvm && { LATEST_RVM_RUBY_XY=\"$(rvm ls | grep \"$MATRIX_RUBY_VERSION\" | tail -1 | sed -e 's/^.*\\([0-9]\\+\\.[0-9]\\+\\.[0-9]\\+\\).*$/\\1/g')\"; if [ -z \"$LATEST_RVM_RUBY_XY\" ]; then LATEST_RVM_RUBY_XY=\"${MATRIX_RUBY_VERSION}-head\"; rvm install \"$LATEST_RVM_RUBY\" --no-docs; else echo \"Found RVM Ruby: '${LATEST_RVM_RUBY_XY}'\"; fi; rvm use \"$LATEST_RVM_RUBY_XY\" ;  }"
+    #   * Use $MATRIX_RUBY_VERSION ruby, install if not present
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script20[collapsed=true]\r\e[0KEnsure RVM & ruby is installed"
+    - "if command -v rvm; then if declare -p rvm_path &> /dev/null; then source \"${rvm_path}/scripts/rvm\"; else source \"$HOME/.rvm/scripts/rvm\" || source /etc/profile.d/rvm.sh; fi; fi"
+    - "if command -v rvm && ! grep rvm_install_on_use_flag=1 ~/.rvmrc; then echo rvm_install_on_use_flag=1 >> ~/.rvmrc || echo '== WARNING: ~/.rvmrc is missing rvm_install_on_use_flag=1 and I failed to add it'; fi"
+    - "if command -v rvm; then rvm use \"$MATRIX_RUBY_VERSION\"; else echo \"rvm not detected; skipping 'rvm use'\"; fi"
     - 'ruby --version || :'
     - 'gem list sync || :'
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script20\r\e[0K"
 
     # Bundle gems (preferring cached > local > downloaded resources)
     #   * Try to use cached and local resources before downloading dependencies
-    - 'declare GEM_BUNDLER_VER=(-v "~> ${BUNDLER_VERSION:-1.17.1}")'
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script30[collapsed=true]\r\e[0KBundle gems (preferring cached > local > downloaded resources)"
+    - 'declare GEM_BUNDLER_VER=(-v "~> ${BUNDLER_VERSION:-2.2.6}")'
     - 'declare GEM_INSTALL_CMD=(gem install --no-document)'
     - 'declare BUNDLER_INSTALL_CMD=(bundle install --no-binstubs --jobs $(nproc) "${FLAGS[@]}")'
     - 'mkdir -p ${GEM_HOME} ${BUNDLER_BIN}'
     - 'gem list -ie "${GEM_BUNDLER_VER[@]}" --silent bundler || "${GEM_INSTALL_CMD[@]}" --local "${GEM_BUNDLER_VER[@]}" bundler || "${GEM_INSTALL_CMD[@]}" "${GEM_BUNDLER_VER[@]}" bundler'
     - 'rm -rf pkg/ || :'
     - 'bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL_CMD[@]}" --local || "${BUNDLER_INSTALL_CMD[@]}" || bundle pristine ||  "${BUNDLER_INSTALL_CMD[@]}") || { echo "PIPELINE: Bundler could not install everything (see log output above)" && exit 99 ; }'
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script30\r\e[0K"
 
     # Diagnostic bundler, ruby, and gem checks:
+    - echo -e "\e[0Ksection_start:`date +%s`:before_script40[collapsed=true]\r\e[0KDiagnostic bundler, ruby, and gem checks"
     - 'bundle exec rvm ls || :'
     - 'bundle exec which ruby || :'
     - 'bundle show sync || :'
     - 'bundle exec gem list sync || :'
+    - echo -e "\e[0Ksection_end:`date +%s`:before_script40\r\e[0K"
+
+
+# Assign a matrix level when your test will run.  Heavier jobs get higher numbers
+# NOTE: To skip all jobs with a SIMP_MATRIX_LEVEL, set SIMP_MATRIX_LEVEL=0
+
+.relevant_file_conditions_trigger_spec_tests: &relevant_file_conditions_trigger_spec_tests
+  changes:
+    - .gitlab-ci.yml
+    - .fixtures.yml
+    - "spec/spec_helper.rb"
+    - "spec/{bin,lib,test_utils}/**/*.rb"
+    - "{bin,ext,lib}/**/*"
+    - "Gemfile"
+  exists:
+    - "spec/{lib,bin}/**/*_spec.rb"
+
+.relevant_file_conditions_trigger_acceptance_tests: &relevant_file_conditions_trigger_acceptance_tests
+  changes:
+    - .gitlab-ci.yml
+    - .fixtures.yml
+    - "spec/spec_helper_acceptance.rb"
+    - "spec/{acceptance,support}/**/*"
+    - "{bin,ext,lib}/**/*"
+    - "Gemfile"
+  exists:
+    - "spec/acceptance/**/*_spec.rb"
+
+# For some reason, the rule regexes stopped matching line starts inside
+# $CI_COMMIT_MESSAGE with carets /^/, so we're using /\n?/ as a workaround.
+.skip_job_when_commit_message_says_to: &skip_job_when_commit_message_says_to
+  if: '$CI_COMMIT_MESSAGE =~ /\n?CI: (SKIP MATRIX|MATRIX LEVEL 0)/'
+  when: never
+
+.force_run_job_when_commit_message_lvl_1_or_above: &force_run_job_when_commit_mssage_lvl_1_or_above
+  if: '$CI_COMMIT_MESSAGE =~ /\n?CI: MATRIX LEVEL [123]/'
+  when: on_success
+
+.force_run_job_when_commit_message_lvl_2_or_above: &force_run_job_when_commit_mssage_lvl_2_or_above
+  if: '$CI_COMMIT_MESSAGE =~ /\n?CI: MATRIX LEVEL [23]/'
+  when: on_success
+
+.force_run_job_when_commit_message_lvl_3_or_above: &force_run_job_when_commit_mssage_lvl_3_or_above
+  if: '$CI_COMMIT_MESSAGE =~ /\n?CI: MATRIX LEVEL [3]/'
+  when: on_success
+
+# check for $CI_PIPELINE_SOURCE needed because this is combined w/when:changes
+.run_job_when_level_1_or_above_w_changes: &run_job_when_level_1_or_above_w_changes
+  if: '$SIMP_MATRIX_LEVEL =~ /^[123]$/ && $CI_COMMIT_BRANCH && $CI_PIPELINE_SOURCE == "push"'
+  when: on_success
+
+.run_job_when_level_2_or_above_w_changes: &run_job_when_level_2_or_above_w_changes
+  if: '$SIMP_MATRIX_LEVEL =~ /^[23]$/ && $CI_COMMIT_BRANCH && $CI_PIPELINE_SOURCE == "push"'
+  when: on_success
+
+.run_job_when_level_3_or_above_w_changes: &run_job_when_level_3_or_above_w_changes
+  if: '$SIMP_MATRIX_LEVEL =~ /^[3]$/ && $CI_COMMIT_BRANCH && $CI_PIPELINE_SOURCE == "push"'
+  when: on_success
+
+.force_run_job_when_var_and_lvl_1_or_above: &force_run_job_when_var_and_lvl_1_or_above
+  if: '$SIMP_FORCE_RUN_MATRIX == "yes" && $SIMP_MATRIX_LEVEL =~ /^[123]$/'
+  when: on_success
+
+.force_run_job_when_var_and_lvl_2_or_above: &force_run_job_when_var_and_lvl_2_or_above
+  if: '$SIMP_FORCE_RUN_MATRIX == "yes" && $SIMP_MATRIX_LEVEL =~ /^[23]$/'
+  when: on_success
+
+.force_run_job_when_var_and_lvl_3_or_above: &force_run_job_when_var_and_lvl_3_or_above
+  if: '$SIMP_FORCE_RUN_MATRIX == "yes" && $SIMP_MATRIX_LEVEL =~ /^[3]$/'
+  when: on_success
+
+
+
+# SIMP_MATRIX_LEVEL=1: Intended to run every commit
+.with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1: &with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
+  rules:
+    - <<: *skip_job_when_commit_message_says_to
+    - <<: *force_run_job_when_var_and_lvl_1_or_above
+    - <<: *force_run_job_when_commit_mssage_lvl_1_or_above
+    - <<: *run_job_when_level_1_or_above_w_changes
+      <<: *relevant_file_conditions_trigger_acceptance_tests
+    - when: never
+
+.with_SIMP_SPEC_MATRIX_LEVEL_1: &with_SIMP_SPEC_MATRIX_LEVEL_1
+  rules:
+    - <<: *skip_job_when_commit_message_says_to
+    - <<: *force_run_job_when_commit_mssage_lvl_1_or_above
+    - <<: *force_run_job_when_var_and_lvl_1_or_above
+    - <<: *run_job_when_level_1_or_above_w_changes
+      <<: *relevant_file_conditions_trigger_spec_tests
+    - when: never
+
+# SIMP_MATRIX_LEVEL=2: Resource-heavy or redundant jobs
+.with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2: &with_SIMP_ACCEPTANCE_MATRIX_LEVEL_2
+  rules:
+    - <<: *skip_job_when_commit_message_says_to
+    - <<: *force_run_job_when_var_and_lvl_2_or_above
+    - <<: *force_run_job_when_commit_mssage_lvl_2_or_above
+    - <<: *run_job_when_level_2_or_above_w_changes
+      <<: *relevant_file_conditions_trigger_acceptance_tests
+    - when: never
+
+.with_SIMP_SPEC_MATRIX_LEVEL_2: &with_SIMP_SPEC_MATRIX_LEVEL_2
+  rules:
+    - <<: *skip_job_when_commit_message_says_to
+    - <<: *force_run_job_when_commit_mssage_lvl_2_or_above
+    - <<: *force_run_job_when_var_and_lvl_2_or_above
+    - <<: *run_job_when_level_2_or_above_w_changes
+      <<: *relevant_file_conditions_trigger_spec_tests
+    - when: never
+
+# SIMP_MATRIX_LEVEL=3: Reserved for FULL matrix testing
+.with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3: &with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
+  rules:
+    - <<: *skip_job_when_commit_message_says_to
+    - <<: *force_run_job_when_var_and_lvl_3_or_above
+    - <<: *force_run_job_when_commit_mssage_lvl_3_or_above
+    - <<: *run_job_when_level_3_or_above_w_changes
+      <<: *relevant_file_conditions_trigger_acceptance_tests
+    - when: never
 
 
 # Puppet Versions
@@ -108,6 +238,7 @@ variables:
   stage: 'validation'
   tags: ['docker']
   <<: *setup_bundler_env
+  <<: *with_SIMP_SPEC_MATRIX_LEVEL_1
   script:
     # simp cli code uses libpwquality or cracklib to validate passwords and
     # rsync in simp environment commands
@@ -119,12 +250,13 @@ variables:
     - 'if `hash apt-get`; then ln -s /usr/bin/grub-mkpasswd-pbkdf2 /usr/bin/grub2-mkpasswd-pbkdf2 ; fi'
     # simp cli code fetches USER env variable.  In the docker container USER is
     # not available, but the process is running as root.
-    - 'USER=root SIMP_SKIP_NON_SIMPOS_TESTS=1 bundle exec rake spec'
+    - 'USER=root bundle exec rake spec'
 
 .acceptance_base: &acceptance_base
   stage: 'acceptance'
   tags: ['beaker']
   <<: *setup_bundler_env
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_1
 
 # Pipeline / testing matrix
 #=======================================================================
@@ -142,11 +274,14 @@ releng_checks:
     - 'bundle exec rake pkg:create_tag_changelog'
     - 'bundle exec rake pkg:gem'
 
+
 # Unit Tests
 #-----------------------------------------------------------------------
+
 pup6.x-unit:
   <<: *pup_6_x
   <<: *unit_tests
+  <<: *with_SIMP_SPEC_MATRIX_LEVEL_2
 
 pup6.pe-unit:
   <<: *pup_6_pe
@@ -157,38 +292,26 @@ pup7.x-unit:
   <<: *unit_tests
 
 
-# Test control variables
-#=======================================================================
-#
-
-# To avoid running a prohibitive number of tests every commit,
-# don't set this env var in your gitlab instance
-.only_with_SIMP_FULL_MATRIX: &only_with_SIMP_FULL_MATRIX
-  only:
-    variables:
-      - $SIMP_FULL_MATRIX
-
-
 # Acceptance tests
 # ==============================================================================
 pup6.pe:
   <<: *pup_6_pe
-  <<: *only_with_SIMP_FULL_MATRIX
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[default,default]'
 
 pup6.pe_config:
   <<: *pup_6_pe
-  <<: *only_with_SIMP_FULL_MATRIX
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[config,default]'
 
 pup6.pe_simp_kv:
   <<: *pup_6_pe
-  <<: *only_with_SIMP_FULL_MATRIX
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[simp_kv,default]'
 
@@ -200,8 +323,8 @@ pup6.x:
 
 pup6.x-fips:
   <<: *pup_6_x
-  <<: *only_with_SIMP_FULL_MATRIX
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,default]'
 
@@ -223,8 +346,8 @@ pup6.x_centos8-fips:
 
 pup6.x_config:
   <<: *pup_6_x
-  <<: *only_with_SIMP_FULL_MATRIX
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[config,default]'
 
@@ -238,23 +361,23 @@ pup6.x_config_centos8:
 # algorithm used is MD5
 pup6.x_config_centos8-fips:
   <<: *pup_6_x
-  <<: *only_with_SIMP_FULL_MATRIX
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   allow_failure: true
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[config,centos8]'
 
 pup6.x_simp_kv:
   <<: *pup_6_x
-  <<: *only_with_SIMP_FULL_MATRIX
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'bundle exec rake beaker:suites[simp_kv,default]'
 
 pup6.x_simp_kv-fips:
   <<: *pup_6_x
-  <<: *only_with_SIMP_FULL_MATRIX
   <<: *acceptance_base
+  <<: *with_SIMP_ACCEPTANCE_MATRIX_LEVEL_3
   script:
     - 'BEAKER_fips=yes bundle exec rake beaker:suites[simp_kv,default]'
 

--- a/spec/acceptance/nodesets/centos8.yml
+++ b/spec/acceptance/nodesets/centos8.yml
@@ -10,7 +10,7 @@ HOSTS:
     roles:
       - default
     platform: el-8-x86_64
-    box: centos/8
+    box: generic/centos8
     hypervisor: <%= hypervisor %>
 
 CONFIG:
@@ -20,6 +20,7 @@ CONFIG:
   ssh:
     keepalive: true
     keepalive_interval: 1
+    keepalive_maxcount: 60
   synced_folder : disabled
   type: aio
 

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -20,6 +20,7 @@ CONFIG:
   ssh:
     keepalive: true
     keepalive_interval: 1
+    keepalive_maxcount: 60
   synced_folder : disabled
   type: aio
 

--- a/spec/acceptance/shared_examples/configure_puppet_env.rb
+++ b/spec/acceptance/shared_examples/configure_puppet_env.rb
@@ -21,11 +21,11 @@ shared_examples 'configure puppet env' do |host,env|
 
   it "should wait for the reloaded puppetserver to be available on #{host}" do
     # wait for it to come up
-    master_fqdn = fact_on(host, 'fqdn')
+    fqdn = fact_on(host, 'fqdn')
     puppetserver_status_cmd = [
       'curl -sSk',
-      "--cert /etc/puppetlabs/puppet/ssl/certs/#{master_fqdn}.pem",
-      "--key /etc/puppetlabs/puppet/ssl/private_keys/#{master_fqdn}.pem",
+      "--cert /etc/puppetlabs/puppet/ssl/certs/#{fqdn}.pem",
+      "--key /etc/puppetlabs/puppet/ssl/private_keys/#{fqdn}.pem",
       "https://localhost:8140/production/certificate_revocation_list/ca",
       '| grep CRL'
     ].join(' ')

--- a/spec/acceptance/shared_examples/fixtures_move.rb
+++ b/spec/acceptance/shared_examples/fixtures_move.rb
@@ -1,13 +1,13 @@
 # move fixtures copies into a staging dir
 #
-shared_examples 'fixtures move' do |master|
+shared_examples 'fixtures move' do |server|
 
   context 'staging of fixtures' do
     let(:fixtures_orig_dest) { '/etc/puppetlabs/code/environments/production/modules' }
     let(:fixtures_staging_dir) { '/root/fixtures' }
 
     it 'should move assets from fixtures install dir to staging dir' do
-      on(master, "mkdir -p #{fixtures_staging_dir}/assets")
+      on(server, "mkdir -p #{fixtures_staging_dir}/assets")
       [
         'adapter',
         'environment_skeleton',
@@ -15,13 +15,13 @@ shared_examples 'fixtures move' do |master|
         'rubygem_simp_cli',
         'simp_selinux_policy'
       ].each do |asset|
-        on(master, "mv #{fixtures_orig_dest}/#{asset} #{fixtures_staging_dir}/assets")
+        on(server, "mv #{fixtures_orig_dest}/#{asset} #{fixtures_staging_dir}/assets")
       end
     end
 
     it 'should move modules from fixtures install dir to staging dir' do
-      on(master, "mkdir -p #{fixtures_staging_dir}/modules")
-      on(master, "mv #{fixtures_orig_dest}/* #{fixtures_staging_dir}/modules")
+      on(server, "mkdir -p #{fixtures_staging_dir}/modules")
+      on(server, "mv #{fixtures_orig_dest}/* #{fixtures_staging_dir}/modules")
     end
   end
 end

--- a/spec/acceptance/shared_examples/kv_test_envs_set_up.rb
+++ b/spec/acceptance/shared_examples/kv_test_envs_set_up.rb
@@ -1,6 +1,6 @@
 # creates simpkv-enabled production and dev SIMP Omni environments, each
 # with two simpkv file backends
-shared_examples 'kv test environments set up' do |master|
+shared_examples 'kv test environments set up' do |server|
 
   context 'module installation from fixtures staging dir' do
     let(:module_staging_dir) { '/root/fixtures/modules' }
@@ -42,17 +42,17 @@ shared_examples 'kv test environments set up' do |master|
 
     it "should create 'production' environment" do
       # remove anything in production Puppet env so we start clean
-      on(master, "rm -rf #{envs_dir}/production")
+      on(server, "rm -rf #{envs_dir}/production")
 
       opts = create_options_base.dup
       opts[:env] = 'production'
-      create_env_and_install_modules(master, opts)
+      create_env_and_install_modules(server, opts)
     end
 
     it "should create 'dev' environment" do
       opts = create_options_base.dup
       opts[:env] = 'dev'
-      create_env_and_install_modules(master, opts)
+      create_env_and_install_modules(server, opts)
     end
 
     it 'should create simpkv directory fully accessible by Puppet for file plugin' do
@@ -60,9 +60,9 @@ shared_examples 'kv test environments set up' do |master|
       # during compilation and will fail before the manifest
       # apply can create the directory!  In other words, the simpkv functions need
       # the directory to be available at compile time.
-      on(master, 'mkdir -p /var/simp/simpkv')
-      on(master, 'chown root:puppet /var/simp/simpkv')
-      on(master, 'chmod 0770 /var/simp/simpkv')
+      on(server, 'mkdir -p /var/simp/simpkv')
+      on(server, 'chown root:puppet /var/simp/simpkv')
+      on(server, 'chmod 0770 /var/simp/simpkv')
     end
   end
 end

--- a/spec/acceptance/shared_examples/passgen_test_envs_set_up.rb
+++ b/spec/acceptance/shared_examples/passgen_test_envs_set_up.rb
@@ -3,7 +3,7 @@
 # * new_simplib_legacy_passgen:  simpkv-enabled simplib::passgen in legacy mode
 # * new_simplib_simpkv_passgen:   simpkv-enabled simplib::passgen in simpkv mode
 
-shared_examples 'passgen test environments set up' do |master|
+shared_examples 'passgen test environments set up' do |server|
 
   context 'module installation from fixtures staging dir' do
     let(:module_staging_dir) { '/root/fixtures/modules' }
@@ -37,13 +37,12 @@ shared_examples 'passgen test environments set up' do |master|
 
     it 'should clone old simplib into fixtures staging dir' do
       # install last simplib version that contains legacy simplib::passgen
-      master.install_package('git')
       cmd = "cd #{module_staging_dir}; " +
         'git clone https://github.com/simp/pupmod-simp-simplib simplib-3.15.3'
-      on(master, cmd)
+      on(server, cmd)
 
       cmd = "cd #{module_staging_dir}/simplib-3.15.3; git checkout tags/3.15.3"
-      on(master, cmd)
+      on(server, cmd)
     end
 
     it 'should create old_simplib environment' do
@@ -57,7 +56,7 @@ shared_examples 'passgen test environments set up' do |master|
 
       opts[:hieradata] = base_hiera.dup
 
-      create_env_and_install_modules(master, opts)
+      create_env_and_install_modules(server, opts)
 
       # Fix name of simplib module
       modules_dir = File.join(opts[:envs_dir], opts[:env], 'modules')
@@ -65,7 +64,7 @@ shared_examples 'passgen test environments set up' do |master|
         File.join(modules_dir, 'simplib-3.15.3'),
         File.join(modules_dir, 'simplib')
       ].join(' ')
-      on(master, cmd)
+      on(server, cmd)
     end
 
     it 'should create new_simplib_legacy_passgen environment' do
@@ -83,7 +82,7 @@ shared_examples 'passgen test environments set up' do |master|
       default_hiera.merge!(simpkv_hiera)
       opts[:hieradata] = default_hiera
 
-      create_env_and_install_modules(master, opts)
+      create_env_and_install_modules(server, opts)
     end
 
     it 'should create new_simplib_simpkv_passgen environment' do
@@ -101,7 +100,7 @@ shared_examples 'passgen test environments set up' do |master|
       default_hiera.merge!(simpkv_hiera)
       opts[:hieradata] = default_hiera
 
-      create_env_and_install_modules(master, opts)
+      create_env_and_install_modules(server, opts)
     end
 
     it 'should create simpkv directory fully accessible by Puppet for file plugin' do
@@ -109,9 +108,9 @@ shared_examples 'passgen test environments set up' do |master|
       # functions run during compilation and will fail before the manifest
       # apply can create the directory!  In other words, the simpkv functions need
       # the directory to be available at compile time.
-      on(master, 'mkdir -p /var/simp/simpkv')
-      on(master, 'chown root:puppet /var/simp/simpkv')
-      on(master, 'chmod 0770 /var/simp/simpkv')
+      on(server, 'mkdir -p /var/simp/simpkv')
+      on(server, 'chown root:puppet /var/simp/simpkv')
+      on(server, 'chmod 0770 /var/simp/simpkv')
     end
   end
 end

--- a/spec/acceptance/shared_examples/puppetserver_set_up.rb
+++ b/spec/acceptance/shared_examples/puppetserver_set_up.rb
@@ -1,25 +1,26 @@
 
-shared_examples 'puppetserver set up' do |master|
+shared_examples 'puppetserver set up' do |server|
 
   context 'puppetserver install and set up' do
     it 'should ensure hostname is set to a FQDN' do
       # FQDN fact seems to be correct even though all the places hostname must
       # be set may not be.
-      fqdn = fact_on(master, 'fqdn')
-      on(master, "hostname #{fqdn}")
-      on(master, "echo #{fqdn} > /etc/hostname")
-      on(master, "sed -i '/HOSTNAME/d' /etc/sysconfig/network")
-      on(master, "echo HOSTNAME=#{fqdn} >> /etc/sysconfig/network")
+#FIXME hostnamectl?
+      fqdn = fact_on(server, 'fqdn')
+      on(server, "hostname #{fqdn}")
+      on(server, "echo #{fqdn} > /etc/hostname")
+      on(server, "sed -i '/HOSTNAME/d' /etc/sysconfig/network")
+      on(server, "echo HOSTNAME=#{fqdn} >> /etc/sysconfig/network")
     end
 
 
     it 'should install puppetserver' do
-      master.install_package('puppetserver')
+      server.install_package('puppetserver')
     end
 
     it 'should configure agent to talk to puppetserver' do
-      master_fqdn = fact_on(master, 'fqdn')
-      on(master, "puppet config set server #{master_fqdn}")
+      server_fqdn = fact_on(server, 'fqdn')
+      on(server, "puppet config set server #{server_fqdn}")
     end
   end
 end

--- a/spec/acceptance/shared_examples/simp_asset_manual_install.rb
+++ b/spec/acceptance/shared_examples/simp_asset_manual_install.rb
@@ -6,6 +6,15 @@ shared_examples 'simp asset manual install' do |server|
     let(:asset_staging_dir) { '/root/fixtures/assets' }
     let(:skeleton_dir) { '/usr/share/simp/environment-skeleton' }
 
+    it 'should ensure packages required by assets are installed' do
+      [
+        'git',
+        'rsync'
+      ].each do |package|
+        install_package_unless_present_on(server, package)
+      end
+    end
+
     it 'should install simp-adapter as done by its RPM' do
       on(server, "cp #{asset_staging_dir}/adapter/src/sbin/simp_rpm_helper /usr/local/sbin/simp_rpm_helper")
       on(server, 'chmod 750 /usr/local/sbin/simp_rpm_helper')

--- a/spec/acceptance/shared_examples/simp_module_git_repos_manual_install.rb
+++ b/spec/acceptance/shared_examples/simp_module_git_repos_manual_install.rb
@@ -9,8 +9,7 @@ shared_examples 'simp module git repos manual install' do |server|
 
     # simp cli will need r10k to access modules in local git repos created
     # by simp_rpm_helper in step below
-    it "should install git RPM and r10k gem into Puppet's Ruby" do
-      server.install_package('git')
+    it "should install r10k gem into Puppet's Ruby" do
       on(server, 'puppet resource package r10k ensure=present provider=puppet_gem')
     end
 

--- a/spec/acceptance/suites/default/00_simp_passgen_set_up_spec.rb
+++ b/spec/acceptance/suites/default/00_simp_passgen_set_up_spec.rb
@@ -4,7 +4,7 @@ test_name 'simp passgen set up'
 
 describe 'simp passgen set up' do
 
-  context 'Puppet master set up' do
+  context 'Puppet server set up' do
     hosts.each do |host|
       include_examples 'configure sshd', host
       include_examples 'fixtures move', host

--- a/spec/acceptance/suites/simp_kv/00_simp_cli_set_up_spec.rb
+++ b/spec/acceptance/suites/simp_kv/00_simp_cli_set_up_spec.rb
@@ -5,7 +5,7 @@ test_name 'simp cli set up'
 describe 'simp cli set up' do
 
   hosts.each do |host|
-    context 'Puppet master set up' do
+    context 'Puppet server set up' do
       include_examples 'configure sshd', host
       include_examples 'fixtures move', host
 

--- a/spec/lib/simp/cli/config/items/action/update_os_yum_repositories_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/update_os_yum_repositories_action_spec.rb
@@ -47,13 +47,12 @@ describe Simp::Cli::Config::Item::UpdateOsYumRepositoriesAction do
       end
 
       it 'creates the yum Updates directory and generates the yum Updates repo metadata' do
+        @ci.silent = false
         @ci.apply
         expect( File.directory?( File.join( @yum_dist_dir, 'Updates') ) ).to eq( true )
 
-        file =  File.join( @yum_dist_dir, 'Updates', 'repodata', 'repomd.xml' )
-        if (value = ENV['SIMP_SKIP_NON_SIMPOS_TESTS'])
-          skip "skipping because env var SIMP_SKIP_NON_SIMPOS_TESTS is set to #{value}"
-        else
+        if Facter::Core::Execution.which('createrepo')
+          file =  File.join( @yum_dist_dir, 'Updates', 'repodata', 'repomd.xml' )
           expect( File.exists?( file )).to eq( true )
           expect( File.size?( file ) ).to  be_truthy
         end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -30,6 +30,10 @@ RSpec.configure do |c|
   # ensure that environment OS is ready on each host
   fix_errata_on hosts
 
+  # Detect cases in which no examples are executed (e.g., nodeset does not
+  # have hosts with required roles)
+  c.fail_if_no_examples = true
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
* Maintenance
  - Test with CentOS 8.4 via generic/centos8 box
  - Updated .gitlab-ci.yml to be closer to Puppet module asset
  - Reworked spec test so that SIMP_SKIP_NON_SIMPOS_TESTS environment
    variable is not necessary. Eliminates one customization in
    .gitlab-ci.yml.
  - Fail acceptance tests if no examples are executed.
  - Replaced most uses of 'master' with 'server' in acceptance tests.

SIMP-10255 #close
[SIMP-9666] #comment rubygem-simp-cli acceptance tests configured

[SIMP-9666]: https://simp-project.atlassian.net/browse/SIMP-9666