### PR TITLE
(SIMP-10025) Bootstrap server status fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -389,12 +389,11 @@ pup6.x_simp_kv_centos8:
   script:
     - 'bundle exec rake beaker:suites[simp_kv,centos8]'
 
-# SIMP-10025 URL to check if puppetserver is up does not exist in Puppet 7
-#pup7.x_centos8:
-#  <<: *pup_7_x
-#  <<: *acceptance_base
-#  script:
-#    - 'bundle exec rake beaker:suites[default,centos8]'
+pup7.x_centos8:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[default,centos8]'
 
 pup7.x_config_centos8:
   <<: *pup_7_x
@@ -402,10 +401,9 @@ pup7.x_config_centos8:
   script:
     - 'bundle exec rake beaker:suites[config,centos8]'
 
-# SIMP-10025 URL to check if puppetserver is up does not exist in Puppet 7
-#pup7.x_simp_kv_centos8:
-#  <<: *pup_7_x
-#  <<: *acceptance_base
-#  script:
-#    - 'bundle exec rake beaker:suites[simp_kv,centos8]'
+pup7.x_simp_kv_centos8:
+  <<: *pup_7_x
+  <<: *acceptance_base
+  script:
+    - 'bundle exec rake beaker:suites[simp_kv,centos8]'
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -244,6 +244,8 @@ variables:
     # rsync in simp environment commands
     - 'if `hash apt-get`; then apt-get update; fi'
     - 'if `hash apt-get`; then apt-get install -y rpm cracklib-runtime openssl libicu-dev rsync; fi'
+    # simp cli needs to be able to get the default route using the 'ip' command
+    - 'if `hash apt-get`; then apt-get install -y iproute2; fi'
     # simp config uses grub2-mkpasswd-pbkdf2 when encrypting a GRUB password,
     # but the command has a different name on Ubuntu
     - 'if `hash apt-get`; then apt-get install -y grub-common; fi'

--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -166,20 +166,20 @@ EOM
 %doc %{gemdir}/doc
 
 %changelog
+* Tue Aug 17 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 7.0.0
+- Changed set/get from `master` to `server` in updates to the puppet
+  configuration
+- Changed the check for puppetserver running from a fragile CRL query to the
+  actual `status` endpoint and moved from `curl` to native `net/http`
+
 * Thu Jun 24 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.0
+- Removed support for EL6
 - simp kv breaking changes:
   - Updated the `simp kv` command suite to work with simp-simpkv
     Puppet module version >= 0.8.0.
     - simp-simpkv 0.8.0 changed how global keys are accessed.
     - Only impacts sites that explicitly enabled the experimental
       simpkv capability.
-
-* Thu Jun 17 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.0.0
-- simp config changes:
-  - The LOCAL sssd domain is no longer needed for sssd to start. The
-    sssd::domains value is now only set if the SIMP server is the LDAP server.
-
-* Tue May 25 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.0
 - simp CLI changes:
   - Dropped support for Puppet 5.
 - simp config changes:
@@ -203,8 +203,10 @@ EOM
   - Fixed a bug in which running `simp config` multiple times could result in
     multiple /etc/hosts entries for the puppetserver.
 
-* Tue Feb 09 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.0.0
+* Thu Jun 17 2021 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 7.0.0
 - simp config changes:
+  - The LOCAL sssd domain is no longer needed for sssd to start. The
+    sssd::domains value is now only set if the SIMP server is the LDAP server.
   - Configure simp_options::ntp::servers instead of deprecated
     simp_options::ntpd::servers.
   - Set the NTP server defaults for ntpd and chronyd.
@@ -216,9 +218,6 @@ EOM
     simp_options::ntp::servers in hieradata.
   - Check for both ntpd and chronyd settings when determining the OS defaults
     for simp_options::ntp::server, not just ntpd settings.
-
-* Mon Jan 11 2021 Liz Nemsick <lnemsick.simp@gmail.com> - 7.0.0
-- Remove support for EL6
 
 * Thu Dec 10 2020 Chris Tessmer <chris.tessmer@onyxpoint.com> - 7.0.0
 - Bumped .gemspec dependencies to mitigate CVE-2020-8130

--- a/lib/simp/cli/commands/passgen/envs.rb
+++ b/lib/simp/cli/commands/passgen/envs.rb
@@ -50,7 +50,7 @@ class Simp::Cli::Commands::Passgen::Envs < Simp::Cli::Commands::Command
   #   for any Puppet environment
   #
   def find_valid_environments
-    # grab the environments path from the production env puppet master config
+    # grab the environments path from the production env puppet server config
     environments_dir = Simp::Cli::Utils.puppet_info[:config]['environmentpath']
     environments = Dir.glob(File.join(environments_dir, '*'))
     environments.map! { |env| File.basename(env) }

--- a/lib/simp/cli/utils.rb
+++ b/lib/simp/cli/utils.rb
@@ -66,8 +66,8 @@ module Simp::Cli::Utils
       }
     end
 
-    def get_config(environment='production', section='master')
-      # Get the master section by default in case things are overridden from
+    def get_config(environment='production', section='server')
+      # Get the server section by default in case things are overridden from
       # main or don't match the agent settings
 
       return %x{puppet config print --environment=#{environment} --section=#{section}}.lines

--- a/spec/acceptance/shared_examples/configure_puppet_env.rb
+++ b/spec/acceptance/shared_examples/configure_puppet_env.rb
@@ -26,8 +26,10 @@ shared_examples 'configure puppet env' do |host,env|
       'curl -sSk',
       "--cert /etc/puppetlabs/puppet/ssl/certs/#{fqdn}.pem",
       "--key /etc/puppetlabs/puppet/ssl/private_keys/#{fqdn}.pem",
-      "https://localhost:8140/production/certificate_revocation_list/ca",
-      '| grep CRL'
+      '-o /dev/null',
+      '-w "%{http_code}\n"',
+      'https://localhost/status/v1/services',
+      '| grep -qe 200'
     ].join(' ')
     retry_on(host, puppetserver_status_cmd, :retry_interval => 10)
   end

--- a/spec/acceptance/shared_examples/configure_puppet_env.rb
+++ b/spec/acceptance/shared_examples/configure_puppet_env.rb
@@ -28,7 +28,7 @@ shared_examples 'configure puppet env' do |host,env|
       "--key /etc/puppetlabs/puppet/ssl/private_keys/#{fqdn}.pem",
       '-o /dev/null',
       '-w "%{http_code}\n"',
-      'https://localhost/status/v1/services',
+      'https://localhost:8140/status/v1/services',
       '| grep -qe 200'
     ].join(' ')
     retry_on(host, puppetserver_status_cmd, :retry_interval => 10)


### PR DESCRIPTION
- Changed the check for puppetserver running from a fragile CRL query to the
  actual `status` endpoint and moved from `curl` to native `net/http`
- Changed set/get from `master` to `server` in updates to the puppet
  configuration

SIMP-10025 #close