### PR TITLE
(SIMP-MAINT) Remove dependency on facter

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -66,7 +66,6 @@ Recommends: createrepo
 Recommends: curl
 Recommends: diffutils
 Recommends: elinks
-Recommends: facter >= 3
 Recommends: git
 Recommends: grep
 Recommends: grub2-tools-minimal
@@ -81,7 +80,7 @@ Recommends: pupmod-simp-simp_grub >= 0.2.1
 Recommends: pupmod-simp-network >= 6.0.3
 Recommends: pupmod-simp-resolv >= 0.1.1
 Recommends: pupmod-simp-simplib >= 3.11.1
-Recommends: puppet >= 6
+Recommends: puppet-agent >= 6
 Recommends: rsync
 Recommends: rubygem(%{gemname}-highline) >= %{highline_version}
 Recommends: sed
@@ -94,7 +93,6 @@ Requires: createrepo
 Requires: curl
 Requires: diffutils
 Requires: elinks
-Requires: facter >= 3
 Requires: git
 Requires: grep
 Requires: grub2-tools-minimal
@@ -109,7 +107,7 @@ Requires: pupmod-simp-simp_grub >= 0.2.1
 Requires: pupmod-simp-network >= 6.0.3
 Requires: pupmod-simp-resolv >= 0.1.1
 Requires: pupmod-simp-simplib >= 3.11.1
-Requires: puppet >= 6
+Requires: puppet-agent >= 6
 Requires: rsync
 Requires: rubygem(%{gemname}-highline) >= %{highline_version}
 Requires: sed


### PR DESCRIPTION
Puppet 7 dropped 'Provides: facter' (may be a bug) so this allows things
to pick up the correct dependency chain