### PR TITLE
(SIMP-10583) simp config fails when /etc/resolv.conf missing EL8

### DIFF
--- a/build/rubygem-simp-cli.spec
+++ b/build/rubygem-simp-cli.spec
@@ -215,6 +215,8 @@ EOM
     is on EL>7.
     - Configures the LDAP server to be the SIMP 389ds accounts instance
     - Configures the LDAP client to communicate with the 389ds server.
+  - Updated the logic that extracts existing DNS configuration to
+    handle scenarios in which /etc/resolv.conf is not available.
   - Added option to configure a local user with ssh and sudo privileges
     to prevent server lockout, when SIMP is not installed from ISO.
     - Especially important for cloud instances when the user does not have

--- a/lib/simp/cli/config/items/data/simp_options_dns_search.rb
+++ b/lib/simp/cli/config/items/data/simp_options_dns_search.rb
@@ -22,7 +22,7 @@ Remember to put these in the appropriate order for your environment!}
         # NOTE: the resolver only uses the last of multiple search declarations
         File.readlines( @file ).select{ |x| x =~ /^search\s+/ }.last.to_s.gsub( /\bsearch\s+/, '').split( /\s+/ )
       else
-        ''
+        []
       end
     end
 

--- a/lib/simp/cli/config/items/data/simp_options_dns_search.rb
+++ b/lib/simp/cli/config/items/data/simp_options_dns_search.rb
@@ -16,9 +16,14 @@ Remember to put these in the appropriate order for your environment!}
     end
 
     def get_os_value
-      # TODO: make this a custom fact?
-      # NOTE: the resolver only uses the last of multiple search declarations
-      File.readlines( @file ).select{ |x| x =~ /^search\s+/ }.last.to_s.gsub( /\bsearch\s+/, '').split( /\s+/ )
+      # TODO: Figure out how to get this info from nmcli
+
+      if File.exist?( @file )
+        # NOTE: the resolver only uses the last of multiple search declarations
+        File.readlines( @file ).select{ |x| x =~ /^search\s+/ }.last.to_s.gsub( /\bsearch\s+/, '').split( /\s+/ )
+      else
+        ''
+      end
     end
 
     # recommend:

--- a/spec/lib/simp/cli/config/items/data/simp_options_dns_search_spec.rb
+++ b/spec/lib/simp/cli/config/items/data/simp_options_dns_search_spec.rb
@@ -43,6 +43,14 @@ describe Simp::Cli::Config::Item::SimpOptionsDNSSearch do
         expect( @ci.recommended_value.first ).to match( /CHANGE THIS/ )
       end
     end
+
+    context 'when /etc/resolv.conf does not exist' do
+      it 'recommends a must-change value (when ipaddress is not available)' do
+        @ci.file = '/does/not/exist/resolv.conf'
+        expect( @ci.recommended_value.size  ).to eq 1
+        expect( @ci.recommended_value.first ).to match( /CHANGE THIS/ )
+      end
+    end
   end
 
 


### PR DESCRIPTION
Updated the logic that extracts existing DNS configuration to
handle scenarios in which /etc/resolv.conf is not available.
- Non-existent /etc/resolv.conf was seen with SIMP 6.6.0 Alpha system
  installed via ISO (EFI) for EL8

SIMP-10583 #close