### PR TITLE
(SIMP-10606) Overrides default GHA gem settings

### DIFF
--- a/.github/workflows.local.json
+++ b/.github/workflows.local.json
@@ -1,0 +1,6 @@
+{
+  "gem_build_command": "bundle exec rake pkg:gem",
+  "gem_release_command": "gem push dist/*.gem",
+  "gem_pkg_dir": "dist",
+  "_comment": "This is used instead of 'bundler/gem_tasks' because it builds highline, too"
+}


### PR DESCRIPTION
This patch adds a local overrides file to force the
tag_deploy_rubygem__github-rpms.yml workflow to build simp-cli's gems
with the `pkg:gem` task.

[SIMP-10606] #comment Add .github/workflows.local.json to repo