### PR TITLE
Fix setting the hostname during 'simp config'

### DIFF
--- a/lib/simp/cli/config/items/action/set_hostname_action.rb
+++ b/lib/simp/cli/config/items/action/set_hostname_action.rb
@@ -40,7 +40,17 @@ module Simp::Cli::Config
         end
       end
 
-      if success && ( get_item( 'cli::network::dhcp' ).value == 'dhcp' )
+      if success && Facter::Core::Execution.which('hostnamectl')
+        success = success && execute("hostnamectl set-hostname #{@fqdn}")
+      end
+
+      begin
+        dhcp_item = get_item('cli::network::dhcp')
+      rescue Simp::Cli::Config::MissingItemError
+        # NOOP
+      end
+
+      if success && dhcp_item && ( dhcp_item.value == 'dhcp' )
         # restart the interface to pick up any domain changes associated
         # with the new hostname, if the interface is configured via DHCP
         interface = get_item( 'cli::network::interface' ).value

--- a/lib/simp/cli/config/scenarios/parts/network_setup
+++ b/lib/simp/cli/config/scenarios/parts/network_setup
@@ -23,6 +23,7 @@
        - SimpOptionsDNSSearch    SKIPQUERY SILENT
    false:                    # don't configure network (but ask for info)
     - CliNetworkHostname
+    - SetHostnameAction       IMMEDIATE # apply this before DNS Items
     - CliNetworkIPAddress
     - CliNetworkNetmask
     - CliNetworkGateway

--- a/lib/simp/cli/version.rb
+++ b/lib/simp/cli/version.rb
@@ -1,5 +1,5 @@
 module Simp; end
 
 class Simp::Cli
-  VERSION = '7.0.0'
+  VERSION = '7.0.1'
 end

--- a/spec/lib/simp/cli/config/files/poss_generated_items_tree.yaml
+++ b/spec/lib/simp/cli/config/files/poss_generated_items_tree.yaml
@@ -32,6 +32,7 @@
        - SimpOptionsDNSSearch    SKIPQUERY SILENT
    false:                    # don't configure network (but ask for info)
     - CliNetworkHostname
+    - SetHostnameAction       IMMEDIATE # apply this before DNS Items
     - CliNetworkIPAddress
     - CliNetworkNetmask
     - CliNetworkGateway

--- a/spec/lib/simp/cli/config/files/simp_generated_items_tree.yaml
+++ b/spec/lib/simp/cli/config/files/simp_generated_items_tree.yaml
@@ -32,6 +32,7 @@
        - SimpOptionsDNSSearch    SKIPQUERY SILENT
    false:                    # don't configure network (but ask for info)
     - CliNetworkHostname
+    - SetHostnameAction       IMMEDIATE # apply this before DNS Items
     - CliNetworkIPAddress
     - CliNetworkNetmask
     - CliNetworkGateway

--- a/spec/lib/simp/cli/config/files/simp_lite_generated_items_tree.yaml
+++ b/spec/lib/simp/cli/config/files/simp_lite_generated_items_tree.yaml
@@ -32,6 +32,7 @@
        - SimpOptionsDNSSearch    SKIPQUERY SILENT
    false:                    # don't configure network (but ask for info)
     - CliNetworkHostname
+    - SetHostnameAction       IMMEDIATE # apply this before DNS Items
     - CliNetworkIPAddress
     - CliNetworkNetmask
     - CliNetworkGateway

--- a/spec/lib/simp/cli/config/items/action/set_hostname_action_spec.rb
+++ b/spec/lib/simp/cli/config/items/action/set_hostname_action_spec.rb
@@ -9,7 +9,7 @@ describe Simp::Cli::Config::Item::SetHostnameAction do
 
   # TODO:  test with acceptance tests
   describe '#apply' do
-    it 'will do set hostname ' do
+    it 'will do set hostname' do
       cli_network_hostname = Simp::Cli::Config::Item::CliNetworkHostname.new
       cli_network_hostname.value = 'foo.bar.baz'
       cli_network_dhcp = Simp::Cli::Config::Item::CliNetworkDHCP.new
@@ -19,6 +19,9 @@ describe Simp::Cli::Config::Item::SetHostnameAction do
         cli_network_dhcp.key => cli_network_dhcp
       }
 
+      expect(Facter::Core::Execution).to receive(:which).with('hostnamectl').and_return('/usr/sbin/hostnamectl')
+
+      expect(@ci).to receive(:execute).with("hostnamectl set-hostname #{cli_network_hostname.value}").and_return(true)
       expect(@ci).to receive(:execute).with("hostname #{cli_network_hostname.value}").and_return(true)
       expect(@ci).to receive(:execute).with("sed -i '/HOSTNAME/d' /etc/sysconfig/network").and_return(true)
       expect(@ci).to receive(:execute).with("echo HOSTNAME=#{cli_network_hostname.value} >> /etc/sysconfig/network").and_return(true)

--- a/spec/lib/simp/cli/environment/dir_env_spec.rb
+++ b/spec/lib/simp/cli/environment/dir_env_spec.rb
@@ -97,9 +97,12 @@ describe Simp::Cli::Environment::DirEnv do
 
       before(:each) do
         # as user root
+        expect(Facter::Core::Execution).to receive(:which).with('rsync').and_return('/usr/bin/rsync')
+
         allow(ENV).to receive(:fetch).with(any_args).and_call_original
         allow(ENV).to receive(:fetch).with('USER').and_return('root')
         allow(described_object).to receive(:execute).with(rsync_cmd).and_return(true)
+
       end
 
       example do


### PR DESCRIPTION
Always set the hostname to the one specified during `simp config` during
the apply phase.

This fixes an edge case where the user could decide on an alternate
hostname but choose not to configure the network interface. In this
case, the hostname would not be set properly and the resulting
`simp bootstrap` would fail to execute

Closes #182
