### PR TITLE
Add GHA action to add new issues to triage project

### DIFF
--- a/.github/workflows/add_new_issue_to_triage_project.yml
+++ b/.github/workflows/add_new_issue_to_triage_project.yml
@@ -1,0 +1,21 @@
+---
+name: Add new issues to triage project
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/simp/projects/11
+          github-token: ${{ secrets.AUTO_TRIAGE_TOKEN }}

--- a/.github/workflows/tag_deploy_rubygem__github-rpms.yml
+++ b/.github/workflows/tag_deploy_rubygem__github-rpms.yml
@@ -88,12 +88,12 @@ jobs:
               grep -w '"gem_release_command"' &> /dev/null; then
             GEM_RELEASE_COMMAND="$(jq -r .gem_release_command "$LOCAL_WORKFLOW_CONFIG_FILE" )"
           fi
-          echo "::set-output name=build_command::${GEM_BUILD_COMMAND}"
-          echo "::set-output name=pkg_dir::${GEM_PKG_DIR}"
-          echo "::set-output name=release_command::${GEM_RELEASE_COMMAND}"
+          echo "build_command=$GEM_BUILD_COMMAND" | tee -a "$GITHUB_OUTPUT"
+          echo "pkg_dir=$GEM_PKG_DIR" | tee -a "$GITHUB_OUTPUT"
+          echo "release_command=$GEM_RELEASE_COMMAND" | tee -a "$GITHUB_OUTPUT"
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: Test build the package
         run: "${{ steps.commands.outputs.build_command }}"


### PR DESCRIPTION
The patch enforces a standardized asset baseline using simp/puppetsync,
and may also apply other updates to ensure conformity.